### PR TITLE
feat: 엔티티의 UUID 자동 생성 기능 추가 (#6)

### DIFF
--- a/src/main/java/com/burntoburn/easyshift/entity/store/Store.java
+++ b/src/main/java/com/burntoburn/easyshift/entity/store/Store.java
@@ -21,6 +21,11 @@ public class Store {
     @Column(nullable = false)
     private String storeName;
 
-    @Column(unique = true, nullable = false)
+    @Column(unique = true, nullable = false, updatable = false)
     private UUID storeCode;
+
+    @PrePersist
+    private void initStoreCode() {
+        this.storeCode = UUID.randomUUID();
+    }
 }

--- a/src/test/java/com/burntoburn/easyshift/entity/store/StoreTest.java
+++ b/src/test/java/com/burntoburn/easyshift/entity/store/StoreTest.java
@@ -1,0 +1,44 @@
+package com.burntoburn.easyshift.entity.store;
+
+import jakarta.persistence.EntityManager;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+import org.springframework.transaction.annotation.Transactional;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@Repository
+interface StoreRepository extends JpaRepository<Store, Long> {}
+
+@SpringBootTest
+class StoreTest {
+    @Autowired
+    private StoreRepository storeRepository;
+    @Autowired
+    private EntityManager entityManager;
+
+    @Test
+    @DisplayName("✅ StoreCode(UUID) 자동 생성 성공")
+    void shouldGenerateUUIDWhenStoreIsCreated() {
+        // Given
+        Store store = Store.builder().storeName("Test Store").build();
+
+        // When
+        Store savedStore = storeRepository.save(store);
+
+        // Then
+        assertNotNull(savedStore.getStoreCode(), "StoreCode(UUID)는 엔티티 생성 시 자동으로 설정되어야 합니다.");
+    }
+
+    @Test
+    @Transactional
+    @DisplayName("✅ StoreCode(UUID) 의 setter 없기 때문에 변경이 불가")
+    void shouldNotUpdateStoreCodeWhenExplicitlyChanged(){
+
+    }
+}


### PR DESCRIPTION
## 작업 내용
- Store 엔티티에 UUID 자동 생성 기능 추가 (@PrePersist 활용)
- UUID 변경 방지 설정 (@Column(updatable = false))
- Store 엔티티 관련 테스트 코드 추가

## 관련 이슈
Closes #6