### PR TITLE
feat: 도커 설정 파일, CI/CD pipeline 설정 추가

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,2 @@
+.git
+Dockerfile

--- a/.github/entrypoint.sh
+++ b/.github/entrypoint.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+set -e
+
+CONFIG_FILE="/app/config/application.properties"
+PROD_CONFIG_FILE="/app/config/application-production.properties"
+
+# Copy the production config file if it doesn't exist
+if [ ! -f "$CONFIG_FILE" ]; then
+  echo "spring.profiles.active=production" > "$CONFIG_FILE"
+elif grep -q "^spring.profiles.active" "$CONFIG_FILE"; then
+  sed -i 's/^spring.profiles.active=.*/spring.profiles.active=production/' "$CONFIG_FILE"
+else
+  echo "spring.profiles.active=production" >> "$CONFIG_FILE"
+fi
+
+# Generate application-production.properties from env variables if provided
+if [ -n "$DB_URL" ] && [ -n "$SERVER_PORT" ] && [ -n "$DB_DIALECT" ] && [ -n "$DB_DRIVER" ] && [ -n "$DB_USERNAME" ] && [ -n "$DB_PASSWORD" ]; then
+  cat > "$PROD_CONFIG_FILE" <<EOF
+server.port=$SERVER_PORT
+spring.datasource.url=$DB_URL
+spring.datasource.driver-class-name=$DB_DRIVER
+spring.jpa.properties.hibernate.dialect=$DB_DIALECT
+spring.datasource.username=$DB_USERNAME
+spring.datasource.password=$DB_PASSWORD
+serverTimezone=UTC&characterEncoding=UTF-8
+EOF
+else
+  echo "Environment variables not set. Skipping production config generation."
+fi
+
+# Start the Spring Boot application with external config location
+exec java -jar app.jar --spring.config.additional-location=file:/app/config/

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -1,0 +1,72 @@
+name: CI/CD Pipeline
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  build:
+    runs-on: ubuntu-22.04
+    env:
+      IMAGE_NAME: codinggroot/easy-schedule
+      IMAGE_TAG: ${{ github.sha }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+
+      - name: Log in to DockerHub
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Build and push multi-arch Docker image with caching
+        run: |
+          docker buildx build \
+            --platform linux/amd64,linux/arm64 \
+            --cache-from=type=registry,ref=${IMAGE_NAME}:cache \
+            --cache-to=type=registry,ref=${IMAGE_NAME}:cache,mode=max \
+            -f Dockerfile \
+            -t ${IMAGE_NAME}:${IMAGE_TAG} \
+            -t ${IMAGE_NAME}:latest \
+            --push .
+
+  deploy:
+    runs-on: ubuntu-22.04
+    needs: build
+    if: github.ref == 'refs/heads/main'
+    env:
+      IMAGE_NAME: codinggroot/easy-schedule
+    steps:
+      - name: Deploy to Production Server
+        uses: appleboy/ssh-action@v1.2.0
+        with:
+          host: ${{ secrets.SSH_HOST }}
+          username: ${{ secrets.SSH_USERNAME }}
+          key: ${{ secrets.SSH_KEY }}
+          script: |
+            echo "Pulling latest image..."
+            docker pull ${{ env.IMAGE_NAME }}:latest
+            echo "1. Stopping and removing existing container..."
+            docker stop easyshift_prod || true
+            docker rm easyshift_prod || true
+            echo "2. Starting new container with DB config..."
+            docker run -d --restart unless-stopped --name easyshift_prod -p 80:${{ secrets.SERVER_PORT }} \
+              --add-host=host.docker.internal:host-gateway \
+              -e SERVER_PORT="${{ secrets.SERVER_PORT }}" \
+              -e DB_URL="${{ secrets.DB_URL }}" \
+              -e DB_DRIVER="${{ secrets.DB_DRIVER }}" \
+              -e DB_DIALECT="${{ secrets.DB_DIALECT }}" \
+              -e DB_USERNAME="${{ secrets.DB_USERNAME }}" \
+              -e DB_PASSWORD="${{ secrets.DB_PASSWORD }}" \
+              ${{ env.IMAGE_NAME }}:latest

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,46 @@
+# ---------------------
+# --- Builder Stage ---
+# ---------------------
+FROM bellsoft/liberica-openjdk-debian:21.0.4-cds AS builder
+
+# Install dependencies and gradle 8.12
+RUN apt-get update && apt-get install -y wget unzip && rm -rf /var/lib/apt/lists/*
+RUN wget -q https://services.gradle.org/distributions/gradle-8.12-bin.zip -O gradle.zip \
+    && unzip gradle.zip -d /opt/gradle \
+    && rm gradle.zip
+ENV GRADLE_HOME=/opt/gradle/gradle-8.12
+ENV PATH=$GRADLE_HOME/bin:$PATH
+
+# Copy project files
+WORKDIR /app
+COPY build.gradle settings.gradle gradlew /app/
+COPY gradle /app/gradle
+COPY src /app/src
+
+# Gradle wrapper check
+RUN chmod +x gradlew && ./gradlew bootJar --no-daemon
+
+# ---------------------
+# --- Runtime Stage ---
+# ---------------------
+FROM bellsoft/liberica-openjdk-debian:21.0.4-cds
+
+# Install tools (for debugging)
+RUN apt-get update && apt-get install -y \
+    curl vim net-tools htop zip unzip \
+    && rm -rf /var/lib/apt/lists/*
+
+# Copy built jar from the builder stage
+WORKDIR /app
+COPY --from=builder /app/build/libs/*.jar app.jar
+
+# Create config directory for dynamic config
+RUN mkdir -p /app/config
+
+# Copy entrypoint script that generates config from environment variables
+COPY .github/entrypoint.sh /app/entrypoint.sh
+RUN chmod +x /app/entrypoint.sh
+
+EXPOSE 8080
+
+ENTRYPOINT ["/app/entrypoint.sh"]


### PR DESCRIPTION
1. 깃허브 secret을 기반으로 properties 파일을 생성하도록 .dockerignore와 entrypoint 스크립트를 추가했습니다.
2. multi-stage build를 위한 도커 파일을 추가했습니다.
3. CI/CD pipeline를 위한 GitHub Actions workflow를 추가했습니다.

develop branch로 넣기에는 애매해서 바로 main으로 PR 날립니다.
참고) 서버쪽 DB의 timezone은 utc로 했습니다.