### PR TITLE
refactor: BaseEntity를 활용한 공통 필드 관리 적용 (#7)

### DIFF
--- a/src/main/java/com/burntoburn/easyshift/EasyShiftApplication.java
+++ b/src/main/java/com/burntoburn/easyshift/EasyShiftApplication.java
@@ -5,10 +5,12 @@ import org.springframework.boot.Banner;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
 @Slf4j
 @SpringBootApplication
 @EnableConfigurationProperties
+@EnableJpaAuditing
 public class EasyShiftApplication {
     
     public static void main(String[] args) {

--- a/src/main/java/com/burntoburn/easyshift/dto/schedule/req/LeaveRequestDto.java
+++ b/src/main/java/com/burntoburn/easyshift/dto/schedule/req/LeaveRequestDto.java
@@ -1,0 +1,4 @@
+package com.burntoburn.easyshift.dto.schedule.req;
+
+public class LeaveRequestDto {
+}

--- a/src/main/java/com/burntoburn/easyshift/dto/schedule/req/ScheduleRequest.java
+++ b/src/main/java/com/burntoburn/easyshift/dto/schedule/req/ScheduleRequest.java
@@ -1,0 +1,4 @@
+package com.burntoburn.easyshift.dto.schedule.req;
+
+public class ScheduleRequest {
+}

--- a/src/main/java/com/burntoburn/easyshift/dto/schedule/req/ScheduleTemplateRequest.java
+++ b/src/main/java/com/burntoburn/easyshift/dto/schedule/req/ScheduleTemplateRequest.java
@@ -1,0 +1,4 @@
+package com.burntoburn.easyshift.dto.schedule.req;
+
+public class ScheduleTemplateRequest {
+}

--- a/src/main/java/com/burntoburn/easyshift/dto/schedule/res/LeaveRequestResponse.java
+++ b/src/main/java/com/burntoburn/easyshift/dto/schedule/res/LeaveRequestResponse.java
@@ -1,0 +1,4 @@
+package com.burntoburn.easyshift.dto.schedule.res;
+
+public class LeaveRequestResponse {
+}

--- a/src/main/java/com/burntoburn/easyshift/dto/schedule/res/ScheduleResponse.java
+++ b/src/main/java/com/burntoburn/easyshift/dto/schedule/res/ScheduleResponse.java
@@ -1,0 +1,4 @@
+package com.burntoburn.easyshift.dto.schedule.res;
+
+public class ScheduleResponse {
+}

--- a/src/main/java/com/burntoburn/easyshift/dto/schedule/res/ScheduleTemplateResponse.java
+++ b/src/main/java/com/burntoburn/easyshift/dto/schedule/res/ScheduleTemplateResponse.java
@@ -1,0 +1,4 @@
+package com.burntoburn.easyshift.dto.schedule.res;
+
+public class ScheduleTemplateResponse {
+}

--- a/src/main/java/com/burntoburn/easyshift/entity/BaseEntity.java
+++ b/src/main/java/com/burntoburn/easyshift/entity/BaseEntity.java
@@ -1,0 +1,23 @@
+package com.burntoburn.easyshift.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import java.time.LocalDateTime;
+import lombok.Getter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+@Getter
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class) // 자동으로 날짜 필드 값 설정
+public abstract class BaseEntity {
+    @CreatedDate
+    @Column(updatable = false, nullable = false)
+    private LocalDateTime createdAt; // 최초 생성 시간
+
+    @LastModifiedDate // 엔티티가 변경될 때 자동으로 업데이트
+    @Column(nullable = false)
+    private LocalDateTime updatedAt; // 마지막 수정 시간
+}

--- a/src/main/java/com/burntoburn/easyshift/entity/leave/LeaveRequest.java
+++ b/src/main/java/com/burntoburn/easyshift/entity/leave/LeaveRequest.java
@@ -1,5 +1,6 @@
 package com.burntoburn.easyshift.entity.leave;
 
+import com.burntoburn.easyshift.entity.BaseEntity;
 import com.burntoburn.easyshift.entity.user.ApprovalStatus;
 import com.burntoburn.easyshift.entity.schedule.Schedule;
 import com.burntoburn.easyshift.entity.user.User;
@@ -14,7 +15,7 @@ import java.time.LocalDate;
 @NoArgsConstructor(access = AccessLevel.PROTECTED) // JPA 기본 생성자 (protected)
 @AllArgsConstructor // 모든 필드를 포함한 생성자 자동 생성
 @Builder // Lombok Builder 적용
-public class LeaveRequest {
+public class LeaveRequest extends BaseEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/com/burntoburn/easyshift/entity/schedule/Schedule.java
+++ b/src/main/java/com/burntoburn/easyshift/entity/schedule/Schedule.java
@@ -1,5 +1,6 @@
 package com.burntoburn.easyshift.entity.schedule;
 
+import com.burntoburn.easyshift.entity.BaseEntity;
 import com.burntoburn.easyshift.entity.store.Store;
 import jakarta.persistence.*;
 import lombok.*;
@@ -13,7 +14,7 @@ import java.util.List;
 @NoArgsConstructor(access = AccessLevel.PROTECTED) // JPA 기본 생성자 (protected)
 @AllArgsConstructor // 모든 필드를 포함한 생성자 자동 생성
 @Builder // Lombok Builder 적용
-public class Schedule {
+public class Schedule extends BaseEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/com/burntoburn/easyshift/entity/schedule/Shift.java
+++ b/src/main/java/com/burntoburn/easyshift/entity/schedule/Shift.java
@@ -1,5 +1,6 @@
 package com.burntoburn.easyshift.entity.schedule;
 
+import com.burntoburn.easyshift.entity.BaseEntity;
 import com.burntoburn.easyshift.entity.user.User;
 import jakarta.persistence.*;
 import lombok.*;
@@ -13,7 +14,7 @@ import java.time.LocalTime;
 @NoArgsConstructor(access = AccessLevel.PROTECTED) // JPA 기본 생성자 (protected)
 @AllArgsConstructor // 모든 필드를 포함한 생성자 자동 생성
 @Builder // Lombok Builder 적용
-public class Shift {
+public class Shift extends BaseEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/com/burntoburn/easyshift/entity/store/Store.java
+++ b/src/main/java/com/burntoburn/easyshift/entity/store/Store.java
@@ -1,5 +1,6 @@
 package com.burntoburn.easyshift.entity.store;
 
+import com.burntoburn.easyshift.entity.BaseEntity;
 import jakarta.persistence.*;
 import lombok.*;
 
@@ -11,7 +12,7 @@ import java.util.UUID;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
 @Builder // Lombok Builder 적용
-public class Store {
+public class Store extends BaseEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -21,11 +22,18 @@ public class Store {
     @Column(nullable = false)
     private String storeName;
 
-    @Column(unique = true, nullable = false, updatable = false)
+    @Column(unique = true, nullable = false)
     private UUID storeCode;
 
     @PrePersist
     private void initStoreCode() {
         this.storeCode = UUID.randomUUID();
     }
+
+    // 매장 이름 변경하는 메서드
+    public void updateStoreName(String newName) {
+        this.storeName = newName;
+    }
+
+
 }

--- a/src/main/java/com/burntoburn/easyshift/entity/user/User.java
+++ b/src/main/java/com/burntoburn/easyshift/entity/user/User.java
@@ -1,5 +1,6 @@
 package com.burntoburn.easyshift.entity.user;
 
+import com.burntoburn.easyshift.entity.BaseEntity;
 import jakarta.persistence.*;
 import lombok.*;
 
@@ -9,7 +10,7 @@ import lombok.*;
 @NoArgsConstructor(access = AccessLevel.PROTECTED) // JPA 기본 생성자 (protected)
 @AllArgsConstructor // 모든 필드를 포함한 생성자 자동 생성
 @Builder // Lombok Builder 적용
-public class User {
+public class User extends BaseEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -26,4 +27,9 @@ public class User {
     private Role role; // WORKER, ADMINISTRATOR
 
     private String avatarUrl;
+
+    // 매장 이름 변경하는 메서드
+    public void updateEmail(String newEmail) {
+        this.email = newEmail;
+    }
 }

--- a/src/main/java/com/burntoburn/easyshift/repository/leave/LeaveRequestRepository.java
+++ b/src/main/java/com/burntoburn/easyshift/repository/leave/LeaveRequestRepository.java
@@ -1,0 +1,9 @@
+package com.burntoburn.easyshift.repository.leave;
+
+import com.burntoburn.easyshift.entity.leave.LeaveRequest;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface LeaveRequestRepository extends JpaRepository<LeaveRequest, Long> {
+}

--- a/src/main/java/com/burntoburn/easyshift/repository/schedule/ScheduleRepository.java
+++ b/src/main/java/com/burntoburn/easyshift/repository/schedule/ScheduleRepository.java
@@ -1,0 +1,10 @@
+package com.burntoburn.easyshift.repository.schedule;
+
+import com.burntoburn.easyshift.entity.schedule.Schedule;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface ScheduleRepository extends JpaRepository<Schedule, Long> {
+
+}

--- a/src/main/java/com/burntoburn/easyshift/repository/schedule/ScheduleTemplateRepository.java
+++ b/src/main/java/com/burntoburn/easyshift/repository/schedule/ScheduleTemplateRepository.java
@@ -1,0 +1,10 @@
+package com.burntoburn.easyshift.repository.schedule;
+
+import com.burntoburn.easyshift.entity.schedule.ScheduleTemplate;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface ScheduleTemplateRepository extends JpaRepository<ScheduleTemplate, Long> {
+
+}

--- a/src/main/java/com/burntoburn/easyshift/repository/schedule/ShiftRepository.java
+++ b/src/main/java/com/burntoburn/easyshift/repository/schedule/ShiftRepository.java
@@ -1,0 +1,9 @@
+package com.burntoburn.easyshift.repository.schedule;
+
+import com.burntoburn.easyshift.entity.schedule.Shift;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface ShiftRepository extends JpaRepository<Shift, Long> {
+}

--- a/src/main/java/com/burntoburn/easyshift/repository/store/StoreRepository.java
+++ b/src/main/java/com/burntoburn/easyshift/repository/store/StoreRepository.java
@@ -1,0 +1,9 @@
+package com.burntoburn.easyshift.repository.store;
+
+import com.burntoburn.easyshift.entity.store.Store;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface StoreRepository extends JpaRepository<Store, Long> {
+}

--- a/src/main/java/com/burntoburn/easyshift/repository/user/UserRepository.java
+++ b/src/main/java/com/burntoburn/easyshift/repository/user/UserRepository.java
@@ -1,0 +1,9 @@
+package com.burntoburn.easyshift.repository.user;
+
+import com.burntoburn.easyshift.entity.user.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface UserRepository extends JpaRepository<User, Long> {
+}

--- a/src/main/java/com/burntoburn/easyshift/service/schedule/ScheduleLeaveService.java
+++ b/src/main/java/com/burntoburn/easyshift/service/schedule/ScheduleLeaveService.java
@@ -1,0 +1,17 @@
+package com.burntoburn.easyshift.service.schedule;
+
+import com.burntoburn.easyshift.dto.schedule.req.LeaveRequestDto;
+import com.burntoburn.easyshift.dto.schedule.res.LeaveRequestResponse;
+import java.util.List;
+
+public interface ScheduleLeaveService {
+    // 스케줄 휴무 신청
+    LeaveRequestResponse requestLeave(Long scheduleId, LeaveRequestDto request);
+
+    // 특정 스케줄의 휴무 신청 목록 조회
+    List<LeaveRequestResponse> getLeaveRequests(Long scheduleId);
+
+    // 휴무 신청 승인 또는 거절
+    LeaveRequestResponse approveLeaveRequest(Long leaveRequestId, boolean isApproved);
+
+}

--- a/src/main/java/com/burntoburn/easyshift/service/schedule/ScheduleService.java
+++ b/src/main/java/com/burntoburn/easyshift/service/schedule/ScheduleService.java
@@ -1,0 +1,21 @@
+package com.burntoburn.easyshift.service.schedule;
+
+
+import com.burntoburn.easyshift.dto.schedule.req.ScheduleRequest;
+import com.burntoburn.easyshift.dto.schedule.res.ScheduleResponse;
+import java.util.List;
+
+public interface ScheduleService {
+
+    // 스케줄 생성
+    ScheduleResponse createSchedule(ScheduleRequest request);
+
+    // 스케줄 삭제
+    void deleteSchedule(Long scheduleId);
+
+    // 스케줄 조회 (매장)
+    List<ScheduleResponse> getSchedulesByStore(Long storeId);
+
+    // 스케줄 조회 (근로자) - 자신의 특정 스케줄(월 단위) 조회
+    List<ScheduleResponse> getSchedulesByWorker(Long storeId, Long userId, String date);
+}

--- a/src/main/java/com/burntoburn/easyshift/service/schedule/ScheduleTemplateService.java
+++ b/src/main/java/com/burntoburn/easyshift/service/schedule/ScheduleTemplateService.java
@@ -1,0 +1,20 @@
+package com.burntoburn.easyshift.service.schedule;
+
+import com.burntoburn.easyshift.dto.schedule.req.ScheduleTemplateRequest;
+import com.burntoburn.easyshift.dto.schedule.res.ScheduleTemplateResponse;
+import java.util.List;
+
+public interface ScheduleTemplateService {
+
+    // 특정 매장의 모든 스케줄 템플릿 조회
+    List<ScheduleTemplateResponse> getScheduleTemplatesByStore(Long storeId);
+
+    // 스케줄 템플릿 생성
+    ScheduleTemplateResponse createScheduleTemplate(ScheduleTemplateRequest request);
+
+    // 스케줄 템플릿 수정
+    ScheduleTemplateResponse updateScheduleTemplate(Long templateId, ScheduleTemplateRequest request);
+
+    // 스케줄 템플릿 삭제
+    void deleteScheduleTemplate(Long templateId);
+}

--- a/src/main/java/com/burntoburn/easyshift/service/schedule/imp/ScheduleLeaveServiceImpl.java
+++ b/src/main/java/com/burntoburn/easyshift/service/schedule/imp/ScheduleLeaveServiceImpl.java
@@ -1,0 +1,4 @@
+package com.burntoburn.easyshift.service.schedule.imp;
+
+public class ScheduleLeaveServiceImpl {
+}

--- a/src/main/java/com/burntoburn/easyshift/service/schedule/imp/ScheduleServiceImp.java
+++ b/src/main/java/com/burntoburn/easyshift/service/schedule/imp/ScheduleServiceImp.java
@@ -1,0 +1,4 @@
+package com.burntoburn.easyshift.service.schedule.imp;
+
+public class ScheduleServiceImp {
+}

--- a/src/main/java/com/burntoburn/easyshift/service/schedule/imp/ScheduleTemplateServiceImpl.java
+++ b/src/main/java/com/burntoburn/easyshift/service/schedule/imp/ScheduleTemplateServiceImpl.java
@@ -1,0 +1,4 @@
+package com.burntoburn.easyshift.service.schedule.imp;
+
+public class ScheduleTemplateServiceImpl {
+}

--- a/src/main/java/com/burntoburn/easyshift/service/shift/ShiftService.java
+++ b/src/main/java/com/burntoburn/easyshift/service/shift/ShiftService.java
@@ -1,0 +1,5 @@
+package com.burntoburn.easyshift.service.shift;
+
+public interface ShiftService {
+
+}

--- a/src/main/java/com/burntoburn/easyshift/service/shift/imp/ShiftServiceImp.java
+++ b/src/main/java/com/burntoburn/easyshift/service/shift/imp/ShiftServiceImp.java
@@ -1,0 +1,4 @@
+package com.burntoburn.easyshift.service.shift.imp;
+
+public class ShiftServiceImp {
+}

--- a/src/test/java/com/burntoburn/easyshift/entity/EntityCreationTest.java
+++ b/src/test/java/com/burntoburn/easyshift/entity/EntityCreationTest.java
@@ -1,0 +1,112 @@
+package com.burntoburn.easyshift.entity;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import com.burntoburn.easyshift.entity.leave.LeaveRequest;
+import com.burntoburn.easyshift.entity.schedule.Schedule;
+import com.burntoburn.easyshift.entity.schedule.Shift;
+import com.burntoburn.easyshift.entity.store.Store;
+import com.burntoburn.easyshift.entity.user.User;
+import com.burntoburn.easyshift.repository.leave.LeaveRequestRepository;
+import com.burntoburn.easyshift.repository.schedule.ScheduleRepository;
+import com.burntoburn.easyshift.repository.schedule.ShiftRepository;
+import com.burntoburn.easyshift.repository.store.StoreRepository;
+import com.burntoburn.easyshift.repository.user.UserRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+import java.util.UUID;
+
+@Transactional
+@SpringBootTest
+class EntityCreationTest {
+
+    @Autowired private UserRepository userRepository;
+    @Autowired private StoreRepository storeRepository;
+    @Autowired private ScheduleRepository scheduleRepository;
+    @Autowired private ShiftRepository shiftRepository;
+    @Autowired private LeaveRequestRepository leaveRequestRepository;
+
+    private Store store;
+    private User user;
+    private Schedule schedule;
+
+    @BeforeEach
+    void setUp() {
+        store = storeRepository.saveAndFlush(Store.builder()
+                .storeName("Test Store")
+                .storeCode(UUID.randomUUID())
+                .build());
+
+        user = userRepository.saveAndFlush(User.builder()
+                .email("test@example.com")
+                .phoneNumber("010-1234-5678")
+                .role(com.burntoburn.easyshift.entity.user.Role.WORKER)
+                .avatarUrl("https://example.com/avatar.png")
+                .build());
+
+        schedule = scheduleRepository.save(Schedule.builder()
+                .scheduleName("Test Schedule")
+                .scheduleMonth("2024-11")
+                .description("Test Description")
+                .scheduleStatus(com.burntoburn.easyshift.entity.schedule.ScheduleStatus.PENDING)
+                .store(store)
+                .build());
+    }
+
+    @Test
+    @DisplayName("User 엔티티 생성 시 createdAt 자동 설정 확인")
+    void shouldSetCreatedAtForUser() {
+        assertNotNull(user.getCreatedAt(), "❌ createdAt이 설정되지 않았습니다.");
+        System.out.println("User CreatedAt: " + user.getCreatedAt());
+    }
+
+    @Test
+    @DisplayName("Store 엔티티 생성 시 createdAt 자동 설정 확인")
+    void shouldSetCreatedAtForStore() {
+        assertNotNull(store.getCreatedAt(), "❌ createdAt이 설정되지 않았습니다.");
+        System.out.println("Store CreatedAt: " + store.getCreatedAt());
+    }
+
+    @Test
+    @DisplayName("Schedule 엔티티 생성 시 createdAt 자동 설정 확인")
+    void shouldSetCreatedAtForSchedule() {
+        assertNotNull(schedule.getCreatedAt(), "❌ createdAt이 설정되지 않았습니다.");
+        System.out.println("Schedule CreatedAt: " + schedule.getCreatedAt());
+    }
+
+    @Test
+    @DisplayName("Shift 엔티티 생성 시 createdAt 자동 설정 확인")
+    void shouldSetCreatedAtForShift() {
+        Shift shift = shiftRepository.save(Shift.builder()
+                .shiftName("Morning Shift")
+                .shiftDate(LocalDate.now())
+                .startTime(LocalDate.now().atTime(9, 0).toLocalTime())
+                .endTime(LocalDate.now().atTime(13, 0).toLocalTime())
+                .schedule(schedule)
+                .user(user)
+                .build());
+
+        assertNotNull(shift.getCreatedAt(), "❌ createdAt이 설정되지 않았습니다.");
+        System.out.println("Shift CreatedAt: " + shift.getCreatedAt());
+    }
+
+    @Test
+    @DisplayName("LeaveRequest 엔티티 생성 시 createdAt 자동 설정 확인")
+    void shouldSetCreatedAtForLeaveRequest() {
+        LeaveRequest leaveRequest = leaveRequestRepository.save(LeaveRequest.builder()
+                .date(LocalDate.now())
+                .approvalStatus(com.burntoburn.easyshift.entity.user.ApprovalStatus.PENDING)
+                .user(user)
+                .schedule(schedule)
+                .build());
+
+        assertNotNull(leaveRequest.getCreatedAt(), "❌ createdAt이 설정되지 않았습니다.");
+        System.out.println("LeaveRequest CreatedAt: " + leaveRequest.getCreatedAt());
+    }
+}

--- a/src/test/java/com/burntoburn/easyshift/entity/EntityUpdateTest.java
+++ b/src/test/java/com/burntoburn/easyshift/entity/EntityUpdateTest.java
@@ -1,0 +1,85 @@
+package com.burntoburn.easyshift.entity;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import com.burntoburn.easyshift.entity.store.Store;
+import com.burntoburn.easyshift.entity.user.User;
+import com.burntoburn.easyshift.repository.store.StoreRepository;
+import com.burntoburn.easyshift.repository.user.UserRepository;
+import java.time.LocalDateTime;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
+
+@SpringBootTest
+class EntityUpdateTest {
+
+    @Autowired private UserRepository userRepository;
+    @Autowired private StoreRepository storeRepository;
+
+    private Store store;
+    private User user;
+
+    @BeforeEach
+    void setUp() {
+        store = storeRepository.save(Store.builder()
+                .storeName("Test Store")
+                .storeCode(UUID.randomUUID())
+                .build());
+
+        user = userRepository.save(User.builder()
+                .email("test@example.com")
+                .phoneNumber("010-1234-5678")
+                .role(com.burntoburn.easyshift.entity.user.Role.WORKER)
+                .avatarUrl("https://example.com/avatar.png")
+                .build());
+    }
+
+    @Test
+    @Transactional
+    @DisplayName("Store 엔티티 수정 시 updatedAt 변경 확인")
+    void shouldUpdateUpdatedAtForStore() throws InterruptedException {
+        LocalDateTime beforeUpdate = store.getUpdatedAt();
+        assertNotNull(beforeUpdate, "❌ updatedAt이 설정되지 않았습니다.");
+        System.out.println("Before Update: " + beforeUpdate);
+
+        Thread.sleep(1000);
+
+        store = storeRepository.findById(store.getId()).orElseThrow();
+        store.updateStoreName("Updated Store Name");
+
+        storeRepository.saveAndFlush(store);
+
+        LocalDateTime afterUpdate = store.getUpdatedAt();
+        assertNotNull(afterUpdate, "❌ updatedAt이 설정되지 않았습니다.");
+        assertTrue(afterUpdate.isAfter(beforeUpdate), "❌ updatedAt이 변경되지 않았습니다.");
+        System.out.println("After Update: " + afterUpdate);
+    }
+
+    @Test
+    @Transactional
+    @DisplayName("User 엔티티 수정 시 updatedAt 변경 확인")
+    void shouldUpdateUpdatedAtForUser() throws InterruptedException {
+        // Given
+        LocalDateTime beforeUpdate = user.getUpdatedAt();
+        assertNotNull(beforeUpdate, "❌ updatedAt이 설정되지 않았습니다.");
+        System.out.println("Before Update: " + beforeUpdate);
+
+        Thread.sleep(1000);
+
+        // When (User 이메일 변경 후 저장)
+        user = userRepository.findById(user.getId()).orElseThrow();
+        user.updateEmail("updated@example.com");
+        userRepository.saveAndFlush(user); // save()만 호출
+
+        // Then
+        LocalDateTime afterUpdate = user.getUpdatedAt();
+        assertNotNull(afterUpdate, "❌ updatedAt이 설정되지 않았습니다.");
+        assertTrue(afterUpdate.isAfter(beforeUpdate), "❌ updatedAt이 변경되지 않았습니다.");
+        System.out.println("After Update: " + beforeUpdate);
+    }
+}


### PR DESCRIPTION
## 작업 개요
모든 엔티티에서 `createdAt`, `updatedAt` 필드를 `BaseEntity`로 분리하여 관리할 수 있도록 변경했습니다.  
이슈 #7 을 해결하는 PR입니다.

## 변경 사항
- `BaseEntity` 생성 및 `@MappedSuperclass` 적용
- `Store`, `Schedule`, `User` 등의 엔티티가 `BaseEntity`를 상속받도록 수정
- `createdAt`, `updatedAt` 필드를 JPA Auditing(`@EnableJpaAuditing`)으로 자동 값 설정
-  기존 엔티티에서 중복된 `createdAt`, `updatedAt` 필드 제거
- `BaseEntity`의 필드가 정상적으로 동작하는지 확인하는 테스트 코드 추가

## ✅ 테스트 내역
- `EntityCreationTest`: 엔티티 생성 시 `createdAt` 값이 자동 생성되는지 확인
- `EntityUpdateTest`: 엔티티 수정 시 `updatedAt` 값이 자동 갱신되는지 확인

## 🔗 관련 이슈
- Closes #7

p.s 실수로 다른 커밋 내용도 병합해버렸습니다.. 😅 다음부턴 주의해서 올리겠습니당..