### PR TITLE
feat: ShiftTemplate CRUD 기능 및 테스트 추가

### DIFF
--- a/src/main/java/com/burntoburn/easyshift/repository/schedule/ShiftTemplateRepository.java
+++ b/src/main/java/com/burntoburn/easyshift/repository/schedule/ShiftTemplateRepository.java
@@ -1,0 +1,9 @@
+package com.burntoburn.easyshift.repository.schedule;
+
+import com.burntoburn.easyshift.entity.schedule.ShiftTemplate;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ShiftTemplateRepository extends JpaRepository<ShiftTemplate, Long> {
+    Optional<ShiftTemplate> getShiftTemplateById(Long id);
+}

--- a/src/main/java/com/burntoburn/easyshift/service/shift/ShiftTemplateService.java
+++ b/src/main/java/com/burntoburn/easyshift/service/shift/ShiftTemplateService.java
@@ -1,0 +1,21 @@
+package com.burntoburn.easyshift.service.shift;
+
+import com.burntoburn.easyshift.entity.schedule.ShiftTemplate;
+import java.util.List;
+
+public interface ShiftTemplateService {
+    // ShiftTemplate 생성
+    ShiftTemplate createShiftTemplate(ShiftTemplate shiftTemplate);
+
+    // ShiftTemplate 조회 - 단건
+    ShiftTemplate getShiftTemplateOne(Long id);
+
+    // ShiftTemplate 조회 - 전체
+    List<ShiftTemplate> getAllShiftTemplates();
+
+    // ShiftTemplate 수정
+    ShiftTemplate updateShiftTemplate(Long id, ShiftTemplate shiftTemplate);
+
+    // ShiftTemplate 삭제
+    void deleteShiftTemplate(Long id);
+}

--- a/src/main/java/com/burntoburn/easyshift/service/shift/imp/ShiftTemplateServiceImp.java
+++ b/src/main/java/com/burntoburn/easyshift/service/shift/imp/ShiftTemplateServiceImp.java
@@ -1,0 +1,51 @@
+package com.burntoburn.easyshift.service.shift.imp;
+
+import com.burntoburn.easyshift.entity.schedule.ShiftTemplate;
+import com.burntoburn.easyshift.repository.schedule.ShiftTemplateRepository;
+import com.burntoburn.easyshift.service.shift.ShiftTemplateService;
+import java.util.List;
+import java.util.NoSuchElementException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class ShiftTemplateServiceImp implements ShiftTemplateService {
+    private final ShiftTemplateRepository shiftTemplateRepository;
+
+    @Override
+    public ShiftTemplate createShiftTemplate(ShiftTemplate shiftTemplate) {
+        return shiftTemplateRepository.save(shiftTemplate);
+    }
+
+    @Override
+    public ShiftTemplate getShiftTemplateOne(Long id) {
+        return shiftTemplateRepository.getShiftTemplateById(id)
+                .orElseThrow(() -> new NoSuchElementException("ShiftTemplate not found with id: " + id));
+    }
+
+    @Override
+    public List<ShiftTemplate> getAllShiftTemplates() {
+        return shiftTemplateRepository.findAll();
+    }
+
+    @Override
+    public ShiftTemplate updateShiftTemplate(Long id, ShiftTemplate shiftTemplate) {
+        ShiftTemplate existingTemplate = getShiftTemplateOne(id);
+
+        existingTemplate = ShiftTemplate.builder()
+                .id(existingTemplate.getId()) // 기존 ID 유지
+                .shiftTemplateName(shiftTemplate.getShiftTemplateName())
+                .startTime(shiftTemplate.getStartTime())
+                .endTime(shiftTemplate.getEndTime())
+                .build();
+
+        return shiftTemplateRepository.save(existingTemplate);
+    }
+
+    @Override
+    public void deleteShiftTemplate(Long id) {
+        getShiftTemplateOne(id); // 존재하는지 확인
+        shiftTemplateRepository.deleteById(id);
+    }
+}

--- a/src/test/java/com/burntoburn/easyshift/service/shift/imp/ShiftTemplateServiceImpTest.java
+++ b/src/test/java/com/burntoburn/easyshift/service/shift/imp/ShiftTemplateServiceImpTest.java
@@ -1,0 +1,164 @@
+package com.burntoburn.easyshift.service.shift.imp;
+
+import com.burntoburn.easyshift.entity.schedule.ShiftTemplate;
+import com.burntoburn.easyshift.repository.schedule.ShiftTemplateRepository;
+import com.burntoburn.easyshift.service.shift.ShiftTemplateService;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import java.time.LocalTime;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+@SpringBootTest
+class ShiftTemplateServiceImpTest {
+
+    @Autowired
+    private ShiftTemplateService shiftTemplateService; // ✅ 실제 서비스 객체
+
+    @MockitoBean
+    private ShiftTemplateRepository shiftTemplateRepository; // ✅ Mock Repository (Spring Context 내에서 동작)
+
+    @Test
+    @DisplayName("쉬프트 템플릿 생성")
+    void createShiftTemplate() {
+        // Given
+        ShiftTemplate newShiftTemplate = ShiftTemplate.builder()
+                .shiftTemplateName("Evening Shift")
+                .startTime(LocalTime.of(14, 0))
+                .endTime(LocalTime.of(22, 0))
+                .build();
+
+        // Mock 설정: save()가 호출되면 newShiftTemplate 반환
+        when(shiftTemplateRepository.save(any(ShiftTemplate.class))).thenReturn(newShiftTemplate);
+
+        // When
+        ShiftTemplate createdTemplate = shiftTemplateService.createShiftTemplate(newShiftTemplate);
+
+        // Then
+        assertNotNull(createdTemplate);
+        assertEquals("Evening Shift", createdTemplate.getShiftTemplateName());
+        verify(shiftTemplateRepository, times(1)).save(any(ShiftTemplate.class));
+    }
+
+    @Test
+    @DisplayName("쉬프트 템플릿 조회 - 단건")
+    void getShiftTemplateOne() {
+        // Given
+        ShiftTemplate shiftTemplate = ShiftTemplate.builder()
+                .id(1L)
+                .shiftTemplateName("Morning Shift")
+                .startTime(LocalTime.of(9, 0))
+                .endTime(LocalTime.of(17, 0))
+                .build();
+
+        when(shiftTemplateRepository.getShiftTemplateById(anyLong())).thenReturn(Optional.of(shiftTemplate));
+
+        // When
+        ShiftTemplate foundTemplate = shiftTemplateService.getShiftTemplateOne(1L);
+
+        // Then
+        assertNotNull(foundTemplate);
+        assertEquals(1L, foundTemplate.getId());
+        assertEquals("Morning Shift", foundTemplate.getShiftTemplateName());
+        verify(shiftTemplateRepository, times(1)).getShiftTemplateById(anyLong());
+    }
+
+    @Test
+    @DisplayName("쉬프트 템플릿 조회 - 전체")
+    void getAllShiftTemplates() {
+        // Given
+        List<ShiftTemplate> templateList = Arrays.asList(
+                ShiftTemplate.builder()
+                        .shiftTemplateName("Morning Shift")
+                        .startTime(LocalTime.of(9, 0))
+                        .endTime(LocalTime.of(17, 0))
+                        .build(),
+                ShiftTemplate.builder()
+                        .shiftTemplateName("Afternoon Shift")
+                        .startTime(LocalTime.of(13, 0))
+                        .endTime(LocalTime.of(21, 0))
+                        .build()
+        );
+
+        when(shiftTemplateRepository.findAll()).thenReturn(templateList);
+
+        // When
+        List<ShiftTemplate> templates = shiftTemplateService.getAllShiftTemplates();
+
+        // Then
+        assertNotNull(templates);
+        assertEquals(2, templates.size());
+        assertEquals("Morning Shift", templates.get(0).getShiftTemplateName());
+        assertEquals("Afternoon Shift", templates.get(1).getShiftTemplateName());
+        verify(shiftTemplateRepository, times(1)).findAll();
+    }
+
+    @Test
+    @DisplayName("쉬프트 템플릿 업데이트")
+    void updateShiftTemplate() {
+        // Given
+        ShiftTemplate existingTemplate = ShiftTemplate.builder()
+                .id(1L)
+                .shiftTemplateName("Morning Shift")
+                .startTime(LocalTime.of(9, 0))
+                .endTime(LocalTime.of(17, 0))
+                .build();
+
+        ShiftTemplate updatedTemplateDetails = ShiftTemplate.builder()
+                .shiftTemplateName("Evening Shift")
+                .startTime(LocalTime.of(14, 0))
+                .endTime(LocalTime.of(22, 0))
+                .build();
+
+        when(shiftTemplateRepository.getShiftTemplateById(1L)).thenReturn(Optional.of(existingTemplate));
+        when(shiftTemplateRepository.save(any(ShiftTemplate.class))).thenReturn(updatedTemplateDetails);
+
+        // When
+        ShiftTemplate updatedTemplate = shiftTemplateService.updateShiftTemplate(1L, updatedTemplateDetails);
+
+        // Then
+        assertNotNull(updatedTemplate);
+        assertEquals("Evening Shift", updatedTemplate.getShiftTemplateName());
+        verify(shiftTemplateRepository, times(1)).getShiftTemplateById(1L);
+        verify(shiftTemplateRepository, times(1)).save(any(ShiftTemplate.class));
+    }
+
+    @Test
+    @DisplayName("쉬프트 템플릿 삭제")
+    void deleteShiftTemplate() {
+        // Given
+        Long templateId = 1L;
+        ShiftTemplate templateToDelete = ShiftTemplate.builder()
+                .id(templateId)
+                .shiftTemplateName("Night Shift")
+                .startTime(LocalTime.of(21, 0))
+                .endTime(LocalTime.of(5, 0))
+                .build();
+
+        // Mock 설정: 삭제할 객체 조회 가능하도록 설정
+        when(shiftTemplateRepository.getShiftTemplateById(templateId)).thenReturn(Optional.of(templateToDelete));
+
+        // Mock 설정: deleteById() 호출 시 아무 동작도 하지 않도록 설정
+        doNothing().when(shiftTemplateRepository).deleteById(templateId);
+
+        // When
+        shiftTemplateService.deleteShiftTemplate(templateId);
+
+        // Then
+        verify(shiftTemplateRepository, times(1)).getShiftTemplateById(templateId);
+        verify(shiftTemplateRepository, times(1)).deleteById(templateId);
+
+        // 삭제 후 findById()가 Optional.empty()를 반환하는지 검증
+        when(shiftTemplateRepository.findById(templateId)).thenReturn(Optional.empty());
+        Optional<ShiftTemplate> deletedTemplate = shiftTemplateRepository.findById(templateId);
+        assertTrue(deletedTemplate.isEmpty(), "삭제된 ShiftTemplate이 더 이상 존재하지 않아야 합니다.");
+    }
+}


### PR DESCRIPTION
## 📌 변경 사항
- ShiftTemplate CRUD 기능 추가
- ShiftTemplateService 및 ShiftTemplateRepository 구현
- ShiftTemplate CRUD 테스트 코드 작성

## ✅ 주요 기능
- `createShiftTemplate()`: 새로운 ShiftTemplate 생성
- `getShiftTemplateOne()`: 단일 ShiftTemplate 조회
- `getAllShiftTemplates()`: 전체 ShiftTemplate 조회
- `updateShiftTemplate()`: ShiftTemplate 수정
- `deleteShiftTemplate()`: ShiftTemplate 삭제

## 🧪 테스트 수행
<img width="833" alt="image" src="https://github.com/user-attachments/assets/69894942-6515-46b5-aeb5-53660bd25cf6" />