### PR TITLE
feat: Schedule 생성 로직 및 Shift 자동 생성 기능 구현

### DIFF
--- a/src/main/java/com/burntoburn/easyshift/dto/schedule/req/ScheduleRequest.java
+++ b/src/main/java/com/burntoburn/easyshift/dto/schedule/req/ScheduleRequest.java
@@ -1,4 +1,15 @@
 package com.burntoburn.easyshift.dto.schedule.req;
 
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
 public class ScheduleRequest {
+    private String scheduleName;
+    private String scheduleMonth;
 }

--- a/src/main/java/com/burntoburn/easyshift/entity/schedule/Schedule.java
+++ b/src/main/java/com/burntoburn/easyshift/entity/schedule/Schedule.java
@@ -6,7 +6,6 @@ import com.burntoburn.easyshift.entity.store.Store;
 import jakarta.persistence.*;
 import lombok.*;
 
-import java.util.ArrayList;
 import java.util.List;
 
 @Getter
@@ -28,8 +27,6 @@ public class Schedule extends BaseEntity {
     // 예: "2024-11" 형식으로 월 정보를 저장
     @Column(nullable = false)
     private String scheduleMonth;
-
-    private String description;
 
     @Enumerated(EnumType.STRING)
     @Column(nullable = false)

--- a/src/main/java/com/burntoburn/easyshift/entity/schedule/Schedule.java
+++ b/src/main/java/com/burntoburn/easyshift/entity/schedule/Schedule.java
@@ -1,6 +1,7 @@
 package com.burntoburn.easyshift.entity.schedule;
 
 import com.burntoburn.easyshift.entity.BaseEntity;
+import com.burntoburn.easyshift.entity.schedule.collection.Shifts;
 import com.burntoburn.easyshift.entity.store.Store;
 import jakarta.persistence.*;
 import lombok.*;
@@ -38,7 +39,13 @@ public class Schedule extends BaseEntity {
     @JoinColumn(name = "store_id", nullable = false)
     private Store store;
 
-    @OneToMany(mappedBy = "schedule", cascade = CascadeType.ALL, orphanRemoval = true)
     @Builder.Default // 기본값 설정
-    private List<Shift> shifts = new ArrayList<>();
+    private Shifts shifts = new Shifts(); // 일급 컬렉션 적용
+
+    // 스케줄 업데이트 메서드
+    public void updateSchedule(String scheduleName, String scheduleMonth, List<Shift> newShifts) {
+        this.scheduleName = scheduleName;
+        this.scheduleMonth = scheduleMonth;
+        this.shifts.update(newShifts); // 일급 컬렉션 내부에서 관리
+    }
 }

--- a/src/main/java/com/burntoburn/easyshift/entity/schedule/Schedule.java
+++ b/src/main/java/com/burntoburn/easyshift/entity/schedule/Schedule.java
@@ -46,4 +46,9 @@ public class Schedule extends BaseEntity {
         this.scheduleMonth = scheduleMonth;
         this.shifts.update(newShifts); // 일급 컬렉션 내부에서 관리
     }
+
+    public void addShift(List<Shift> newShifts){
+        this.shifts.addAll(newShifts);
+    }
+
 }

--- a/src/main/java/com/burntoburn/easyshift/entity/schedule/Schedule.java
+++ b/src/main/java/com/burntoburn/easyshift/entity/schedule/Schedule.java
@@ -39,6 +39,7 @@ public class Schedule extends BaseEntity {
     @JoinColumn(name = "store_id", nullable = false)
     private Store store;
 
+    @Embedded
     @Builder.Default // 기본값 설정
     private Shifts shifts = new Shifts(); // 일급 컬렉션 적용
 

--- a/src/main/java/com/burntoburn/easyshift/entity/schedule/Shift.java
+++ b/src/main/java/com/burntoburn/easyshift/entity/schedule/Shift.java
@@ -38,6 +38,6 @@ public class Shift extends BaseEntity {
     private Schedule schedule;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "user_id", nullable = false)
+    @JoinColumn(name = "user_id", nullable = true) // 초기 스케줄 생성시 user 정보는 음
     private User user;
 }

--- a/src/main/java/com/burntoburn/easyshift/entity/schedule/Shift.java
+++ b/src/main/java/com/burntoburn/easyshift/entity/schedule/Shift.java
@@ -24,7 +24,7 @@ public class Shift extends BaseEntity {
     @Column(nullable = false)
     private String shiftName;
 
-    @Column(nullable = false)
+    @Column(nullable = true)
     private LocalDate shiftDate;
 
     @Column(nullable = false)

--- a/src/main/java/com/burntoburn/easyshift/entity/schedule/collection/Shifts.java
+++ b/src/main/java/com/burntoburn/easyshift/entity/schedule/collection/Shifts.java
@@ -1,0 +1,47 @@
+package com.burntoburn.easyshift.entity.schedule.collection;
+
+import com.burntoburn.easyshift.entity.schedule.Shift;
+import jakarta.persistence.*;
+import lombok.NoArgsConstructor;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Embeddable
+@NoArgsConstructor
+public class Shifts {
+
+    @OneToMany(mappedBy = "schedule", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<Shift> shiftList = new ArrayList<>();
+
+    // Shift 추가
+    public void add(Shift shift) {
+        shiftList.add(shift);
+    }
+
+    // 여러 개 Shift 추가
+    public void addAll(List<Shift> shifts) {
+        shiftList.addAll(shifts);
+    }
+
+    // 특정 Shift 삭제
+    public void remove(Shift shift) {
+        shiftList.remove(shift);
+    }
+
+    // 전체 삭제
+    public void clear() {
+        shiftList.clear();
+    }
+
+    // Shift 업데이트 (새로운 Shift 리스트로 교체)
+    public void update(List<Shift> newShifts) {
+        shiftList.clear();
+        shiftList.addAll(newShifts);
+    }
+
+    // Shift 리스트 반환 (불변 리스트로 반환하여 외부 수정 방지)
+    public List<Shift> getList() {
+        return new ArrayList<>(shiftList);
+    }
+}

--- a/src/main/java/com/burntoburn/easyshift/repository/schedule/ScheduleRepository.java
+++ b/src/main/java/com/burntoburn/easyshift/repository/schedule/ScheduleRepository.java
@@ -1,10 +1,12 @@
 package com.burntoburn.easyshift.repository.schedule;
 
 import com.burntoburn.easyshift.entity.schedule.Schedule;
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface ScheduleRepository extends JpaRepository<Schedule, Long> {
 
+    List<Schedule> findByStoreId(Long storeId);
 }

--- a/src/main/java/com/burntoburn/easyshift/service/schedule/ScheduleFactory.java
+++ b/src/main/java/com/burntoburn/easyshift/service/schedule/ScheduleFactory.java
@@ -27,12 +27,15 @@ public class ScheduleFactory {
 
         // ShiftTemplate을 기반으로 빈 Shift 목록 생성
         List<Shift> shifts = createShifts(schedule, scheduleTemplate);
-        schedule.getShifts().addAll(shifts);
+
+        schedule.addShift(shifts);
+
         return schedule;
     }
 
     // ScheduleTemplate 을 기반으로 Shift 생성
     public List<Shift> createShifts(Schedule schedule, ScheduleTemplate scheduleTemplate) {
+
         return scheduleTemplate.getShiftTemplates().getList().stream()
                 .map(shiftTemplate -> createShift(schedule, shiftTemplate))
                 .toList();

--- a/src/main/java/com/burntoburn/easyshift/service/schedule/ScheduleFactory.java
+++ b/src/main/java/com/burntoburn/easyshift/service/schedule/ScheduleFactory.java
@@ -1,0 +1,61 @@
+package com.burntoburn.easyshift.service.schedule;
+
+import com.burntoburn.easyshift.dto.schedule.req.ScheduleRequest;
+import com.burntoburn.easyshift.entity.schedule.Schedule;
+import com.burntoburn.easyshift.entity.schedule.ScheduleStatus;
+import com.burntoburn.easyshift.entity.schedule.Shift;
+import com.burntoburn.easyshift.entity.schedule.collection.Shifts;
+import com.burntoburn.easyshift.entity.store.Store;
+import com.burntoburn.easyshift.entity.templates.ScheduleTemplate;
+import com.burntoburn.easyshift.entity.templates.ShiftTemplate;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+@Component
+public class ScheduleFactory {
+
+    // schedule 객체 생성
+    public Schedule createSchedule(Store store, ScheduleTemplate scheduleTemplate, ScheduleRequest request) {
+        Schedule schedule = Schedule.builder()
+                .scheduleName(request.getScheduleName())
+                .scheduleMonth(request.getScheduleMonth())
+                .scheduleStatus(ScheduleStatus.PENDING) // 초기 상태는 PENDING
+                .store(store)
+                .shifts(new Shifts()) // Shifts 초기화
+                .build();
+
+        // ShiftTemplate을 기반으로 빈 Shift 목록 생성
+        List<Shift> shifts = createShifts(schedule, scheduleTemplate);
+        schedule.getShifts().addAll(shifts);
+        return schedule;
+    }
+
+    // ScheduleTemplate 을 기반으로 Shift 생성
+    public List<Shift> createShifts(Schedule schedule, ScheduleTemplate scheduleTemplate) {
+        return scheduleTemplate.getShiftTemplates().getList().stream()
+                .map(shiftTemplate -> createShift(schedule, shiftTemplate))
+                .toList();
+    }
+
+    // 개별 Shift 객체 생성
+    private Shift createShift(Schedule schedule, ShiftTemplate shiftTemplate) {
+        return Shift.builder()
+                .schedule(schedule)
+                .shiftDate(null)
+                .shiftName(shiftTemplate.getShiftTemplateName())
+                .startTime(shiftTemplate.getStartTime())
+                .endTime(shiftTemplate.getEndTime())
+                .build();
+    }
+
+    public Schedule updateSchedule(Schedule schedule, ScheduleRequest request) {
+        schedule.updateSchedule(
+                request.getScheduleName(),
+                request.getScheduleMonth(),
+                schedule.getShifts().getList() // 기존 Shift 유지
+        );
+        return schedule;
+    }
+
+}

--- a/src/main/java/com/burntoburn/easyshift/service/schedule/ScheduleService.java
+++ b/src/main/java/com/burntoburn/easyshift/service/schedule/ScheduleService.java
@@ -1,21 +1,21 @@
 package com.burntoburn.easyshift.service.schedule;
 
-
 import com.burntoburn.easyshift.dto.schedule.req.ScheduleRequest;
-import com.burntoburn.easyshift.dto.schedule.res.ScheduleResponse;
+import com.burntoburn.easyshift.entity.schedule.Schedule;
 import java.util.List;
 
 public interface ScheduleService {
 
     // 스케줄 생성
-    ScheduleResponse createSchedule(ScheduleRequest request);
+    Schedule createSchedule(Long storeId, Long scheduleTemplateId, ScheduleRequest request);
+
+    // 스케줄 수정 (이름, 설명, 날짜 변경)
+    Schedule updateSchedule(Long scheduleId, ScheduleRequest request);
 
     // 스케줄 삭제
     void deleteSchedule(Long scheduleId);
 
-    // 스케줄 조회 (매장)
-    List<ScheduleResponse> getSchedulesByStore(Long storeId);
+    // 매장별 스케줄 조회
+    List<Schedule> getSchedulesByStore(Long storeId);
 
-    // 스케줄 조회 (근로자) - 자신의 특정 스케줄(월 단위) 조회
-    List<ScheduleResponse> getSchedulesByWorker(Long storeId, Long userId, String date);
 }

--- a/src/main/java/com/burntoburn/easyshift/service/schedule/imp/ScheduleServiceImp.java
+++ b/src/main/java/com/burntoburn/easyshift/service/schedule/imp/ScheduleServiceImp.java
@@ -41,7 +41,8 @@ public class ScheduleServiceImp implements ScheduleService {
         Schedule schedule = scheduleFactory.createSchedule(store, scheduleTemplate, request);
 
         // 스케줄 저장 및 반환
-        return scheduleRepository.save(schedule);
+        scheduleRepository.save(schedule);
+        return schedule;
     }
 
     /**

--- a/src/main/java/com/burntoburn/easyshift/service/schedule/imp/ScheduleServiceImp.java
+++ b/src/main/java/com/burntoburn/easyshift/service/schedule/imp/ScheduleServiceImp.java
@@ -1,4 +1,82 @@
 package com.burntoburn.easyshift.service.schedule.imp;
 
-public class ScheduleServiceImp {
+import com.burntoburn.easyshift.dto.schedule.req.ScheduleRequest;
+import com.burntoburn.easyshift.entity.schedule.Schedule;
+import com.burntoburn.easyshift.entity.store.Store;
+import com.burntoburn.easyshift.entity.templates.ScheduleTemplate;
+import com.burntoburn.easyshift.repository.schedule.ScheduleRepository;
+import com.burntoburn.easyshift.repository.schedule.ScheduleTemplateRepository;
+import com.burntoburn.easyshift.repository.store.StoreRepository;
+import com.burntoburn.easyshift.service.schedule.ScheduleFactory;
+import com.burntoburn.easyshift.service.schedule.ScheduleService;
+import java.util.List;
+import java.util.NoSuchElementException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class ScheduleServiceImp implements ScheduleService {
+    private final ScheduleFactory scheduleFactory;
+    private final ScheduleTemplateRepository scheduleTemplateRepository;
+    private final ScheduleRepository scheduleRepository;
+    private final StoreRepository storeRepository;
+
+    /**
+     * 스케줄 생성
+     */
+    @Transactional
+    @Override
+    public Schedule createSchedule(Long storeId, Long scheduleTemplateId, ScheduleRequest request) {
+        // Store 확인
+        Store store = storeRepository.findById(storeId)
+                .orElseThrow(() -> new NoSuchElementException("Store not found"));
+
+        // scheduleTemplate 확인
+        ScheduleTemplate scheduleTemplate = scheduleTemplateRepository.findById(scheduleTemplateId)
+                .orElseThrow(() -> new NoSuchElementException("ScheduleTemplate not found"));
+
+        // 스케줄 생성 (ScheduleFactory 활용)
+        Schedule schedule = scheduleFactory.createSchedule(store, scheduleTemplate, request);
+
+        // 스케줄 저장 및 반환
+        return scheduleRepository.save(schedule);
+    }
+
+    /**
+     * 스케줄 삭제
+     */
+    @Transactional
+    @Override
+    public void deleteSchedule(Long scheduleId) {
+        Schedule schedule = scheduleRepository.findById(scheduleId)
+                .orElseThrow(() -> new NoSuchElementException("Schedule not found"));
+        scheduleRepository.delete(schedule);
+    }
+
+    /**
+     * 스케줄 수정
+     */
+    @Transactional
+    @Override
+    public Schedule updateSchedule(Long scheduleId, ScheduleRequest request) {
+        // 기존 스케줄 조회
+        Schedule existingSchedule = scheduleRepository.findById(scheduleId)
+                .orElseThrow(() -> new NoSuchElementException("Schedule not found"));
+
+        // ScheduleFactory를 사용하여 업데이트 적용
+        Schedule updatedSchedule = scheduleFactory.updateSchedule(existingSchedule, request);
+
+        // 변경 감지를 통해 자동 반영
+        return scheduleRepository.save(updatedSchedule);
+    }
+
+    /**
+     * 매장의 모든 스케줄 조회
+     */
+    @Override
+    public List<Schedule> getSchedulesByStore(Long storeId) {
+        return scheduleRepository.findByStoreId(storeId);
+    }
 }

--- a/src/test/java/com/burntoburn/easyshift/entity/EntityCreationTest.java
+++ b/src/test/java/com/burntoburn/easyshift/entity/EntityCreationTest.java
@@ -53,7 +53,6 @@ class EntityCreationTest {
         schedule = scheduleRepository.save(Schedule.builder()
                 .scheduleName("Test Schedule")
                 .scheduleMonth("2024-11")
-                .description("Test Description")
                 .scheduleStatus(com.burntoburn.easyshift.entity.schedule.ScheduleStatus.PENDING)
                 .store(store)
                 .build());

--- a/src/test/java/com/burntoburn/easyshift/service/schedule/imp/ScheduleServiceImpTest.java
+++ b/src/test/java/com/burntoburn/easyshift/service/schedule/imp/ScheduleServiceImpTest.java
@@ -1,0 +1,185 @@
+package com.burntoburn.easyshift.service.schedule.imp;
+
+import com.burntoburn.easyshift.dto.schedule.req.ScheduleRequest;
+import com.burntoburn.easyshift.entity.schedule.Schedule;
+import com.burntoburn.easyshift.entity.schedule.ScheduleStatus;
+import com.burntoburn.easyshift.entity.store.Store;
+import com.burntoburn.easyshift.entity.templates.ScheduleTemplate;
+import com.burntoburn.easyshift.repository.schedule.ScheduleRepository;
+import com.burntoburn.easyshift.repository.schedule.ScheduleTemplateRepository;
+import com.burntoburn.easyshift.repository.store.StoreRepository;
+import com.burntoburn.easyshift.service.schedule.ScheduleFactory;
+import com.burntoburn.easyshift.service.schedule.ScheduleService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import java.util.List;
+import java.util.NoSuchElementException;
+import java.util.Optional;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+@SpringBootTest
+class ScheduleServiceImpTest {
+
+    @Autowired
+    private ScheduleService scheduleService; // 실제 서비스 객체 주입
+
+    @MockitoBean
+    private ScheduleFactory scheduleFactory;
+
+    @MockitoBean
+    private ScheduleTemplateRepository scheduleTemplateRepository;
+
+    @MockitoBean
+    private ScheduleRepository scheduleRepository;
+
+    @MockitoBean
+    private StoreRepository storeRepository;
+
+    private Store store;
+    private ScheduleTemplate scheduleTemplate;
+    private Schedule existingSchedule;
+
+    @BeforeEach
+    void setUp() {
+        // 더미 Store 생성
+        store = Store.builder()
+                .id(1L)
+                .build();
+
+        // 더미 ScheduleTemplate 생성
+        scheduleTemplate = ScheduleTemplate.builder()
+                .id(1L)
+                .scheduleTemplateName("Morning Shift")
+                .store(store)
+                .build();
+
+        // 기존 스케줄
+        existingSchedule = Schedule.builder()
+                .id(1L)
+                .scheduleName("March Schedule")
+                .scheduleMonth("2024-03")
+                .scheduleStatus(ScheduleStatus.PENDING)
+                .store(store)
+                .build();
+    }
+
+    @Test
+    @DisplayName("스케줄 생성 테스트")
+    void createSchedule() {
+        // Given
+        ScheduleRequest request = ScheduleRequest.builder()
+                .scheduleName("March Schedule")
+                .scheduleMonth("2024-03")
+                .build();
+
+        when(storeRepository.findById(1L)).thenReturn(Optional.of(store));
+        when(scheduleTemplateRepository.findById(1L)).thenReturn(Optional.of(scheduleTemplate));
+        when(scheduleFactory.createSchedule(store, scheduleTemplate, request)).thenReturn(existingSchedule);
+        when(scheduleRepository.save(any(Schedule.class))).thenReturn(existingSchedule);
+
+        // When
+        Schedule createdSchedule = scheduleService.createSchedule(1L, 1L, request);
+
+        // Then
+        assertNotNull(createdSchedule);
+        assertEquals("March Schedule", createdSchedule.getScheduleName());
+        assertEquals("2024-03", createdSchedule.getScheduleMonth());
+
+        // 검증
+        verify(scheduleRepository, times(1)).save(any(Schedule.class));
+    }
+
+    @Test
+    @DisplayName("스케줄 삭제 테스트")
+    void deleteSchedule() {
+        // Given
+        when(scheduleRepository.findById(1L)).thenReturn(Optional.of(existingSchedule));
+        doNothing().when(scheduleRepository).delete(existingSchedule);
+
+        // When
+        scheduleService.deleteSchedule(1L);
+
+        // Then
+        verify(scheduleRepository, times(1)).delete(existingSchedule);
+    }
+
+    @Test
+    @DisplayName("스케줄 수정 테스트")
+    void updateSchedule() {
+        // Given
+        ScheduleRequest request = ScheduleRequest.builder()
+                .scheduleName("Updated March Schedule")
+                .scheduleMonth("2024-03")
+                .build();
+
+        Schedule updatedSchedule = Schedule.builder()
+                .id(1L)
+                .scheduleName("Updated March Schedule")
+                .scheduleMonth("2024-03")
+                .scheduleStatus(ScheduleStatus.PENDING)
+                .store(store)
+                .build();
+
+        when(scheduleRepository.findById(1L)).thenReturn(Optional.of(existingSchedule));
+        when(scheduleFactory.updateSchedule(existingSchedule, request)).thenReturn(updatedSchedule);
+        when(scheduleRepository.save(any(Schedule.class))).thenReturn(updatedSchedule);
+
+        // When
+        Schedule result = scheduleService.updateSchedule(1L, request);
+
+        // Then
+        assertNotNull(result);
+        assertEquals("Updated March Schedule", result.getScheduleName());
+
+        verify(scheduleRepository, times(1)).save(any(Schedule.class));
+    }
+
+    @Test
+    @DisplayName("스케줄 조회 테스트")
+    void getSchedulesByStore() {
+        // Given
+        when(scheduleRepository.findByStoreId(1L)).thenReturn(List.of(existingSchedule));
+
+        // When
+        List<Schedule> result = scheduleService.getSchedulesByStore(1L);
+
+        // Then
+        assertNotNull(result);
+        assertEquals(1, result.size());
+        assertEquals("March Schedule", result.get(0).getScheduleName());
+
+        verify(scheduleRepository, times(1)).findByStoreId(1L);
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 스케줄 삭제 시 예외 발생")
+    void deleteSchedule_NotFound() {
+        // Given
+        when(scheduleRepository.findById(1L)).thenReturn(Optional.empty());
+
+        // When & Then
+        assertThrows(NoSuchElementException.class, () -> scheduleService.deleteSchedule(1L));
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 스케줄 수정 시 예외 발생")
+    void updateSchedule_NotFound() {
+        // Given
+        ScheduleRequest request = ScheduleRequest.builder()
+                .scheduleName("Updated Schedule")
+                .scheduleMonth("2024-03")
+                .build();
+
+        when(scheduleRepository.findById(1L)).thenReturn(Optional.empty());
+
+        // When & Then
+        assertThrows(NoSuchElementException.class, () -> scheduleService.updateSchedule(1L, request));
+    }
+}

--- a/src/test/java/com/burntoburn/easyshift/service/templates/imp/ScheduleTemplateServiceImplTest.java
+++ b/src/test/java/com/burntoburn/easyshift/service/templates/imp/ScheduleTemplateServiceImplTest.java
@@ -1,4 +1,4 @@
-package com.burntoburn.easyshift.service.schedule.imp;
+package com.burntoburn.easyshift.service.templates.imp;
 
 import com.burntoburn.easyshift.dto.schedule.req.ScheduleTemplateRequest;
 import com.burntoburn.easyshift.dto.schedule.req.ShiftTemplateRequest;

--- a/src/test/java/com/burntoburn/easyshift/service/templates/imp/ShiftTemplateServiceImpTest.java
+++ b/src/test/java/com/burntoburn/easyshift/service/templates/imp/ShiftTemplateServiceImpTest.java
@@ -1,4 +1,4 @@
-package com.burntoburn.easyshift.service.shift.imp;
+package com.burntoburn.easyshift.service.templates.imp;
 
 import com.burntoburn.easyshift.entity.templates.ShiftTemplate;
 import com.burntoburn.easyshift.repository.schedule.ShiftTemplateRepository;


### PR DESCRIPTION
## **작업 내용**
### 1. Schedule 생성 로직 구현
  - `Schedule` 생성 시 **빈 `Shift` 자동 생성**  
  - `ScheduleTemplate`을 기반으로 `ShiftTemplate`을 복사하여 초기 `Shift` 리스트 생성  

### 2. first class collection 적용
 - `Schedule`에서 `Shift` 리스트를 직접 관리하도록 **일급 컬렉션(`Shifts`) 활용**
 - `Shift` 추가/삭제/수정 시 `Shifts` 내부에서 관리하도록 구조 변경

### 3. 팩토리 패턴 적용
  - `ScheduleFactory` 도입하여 `Schedule` 및 `Shift` 생성 로직을 분리  
  - `ScheduleService`에서는 **객체 생성 책임을 `Factory`에 위임**하여 SRP(단일 책임 원칙) 준수  

### Mock 기반 단위 테스트 통과
  - `@MockBean`을 활용한 **Mock 기반 단위 테스트 작성**
  - `ScheduleServiceImpTest`에서 `Schedule`, `Shift` 생성 및 수정 테스트 검증  
  - **예외 처리 검증 포함** (`존재하지 않는 스케줄 수정/삭제 시 예외 발생 테스트`)  

## 테스트 결과
<img width="750" alt="image" src="https://github.com/user-attachments/assets/9b627669-5a85-407f-ac6c-82a53e76507a" />

