### PR TITLE
LeaveRequestService 기능 구현

### DIFF
--- a/src/main/java/com/burntoburn/easyshift/dto/schedule/req/LeaveRequestDto.java
+++ b/src/main/java/com/burntoburn/easyshift/dto/schedule/req/LeaveRequestDto.java
@@ -1,4 +1,16 @@
 package com.burntoburn.easyshift.dto.schedule.req;
 
+import java.time.LocalDate;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
 public class LeaveRequestDto {
+    private Long scheduleId;
+    private LocalDate date;
 }

--- a/src/main/java/com/burntoburn/easyshift/entity/leave/LeaveRequest.java
+++ b/src/main/java/com/burntoburn/easyshift/entity/leave/LeaveRequest.java
@@ -36,4 +36,18 @@ public class LeaveRequest extends BaseEntity {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "schedule_id", nullable = false)
     private Schedule schedule;
+
+    // 명시적으로 Update 매서드 추가
+    public LeaveRequest updateDate(LocalDate newDate) {
+        this.date = newDate;
+        return this;
+    }
+
+    public void approvedRequest(){
+        this.approvalStatus = ApprovalStatus.APPROVED;
+    }
+
+    public void rejectRequest(){
+        this.approvalStatus = ApprovalStatus.REJECTED;
+    }
 }

--- a/src/main/java/com/burntoburn/easyshift/repository/leave/LeaveRequestRepository.java
+++ b/src/main/java/com/burntoburn/easyshift/repository/leave/LeaveRequestRepository.java
@@ -1,9 +1,20 @@
 package com.burntoburn.easyshift.repository.leave;
 
 import com.burntoburn.easyshift.entity.leave.LeaveRequest;
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface LeaveRequestRepository extends JpaRepository<LeaveRequest, Long> {
+
+    // 특정 userId 의 모든 휴뮤일 조회
+    @Query("SELECT lr FROM LeaveRequest lr WHERE lr.user.id = :userId")
+    List<LeaveRequest> findAllByUserId(Long userId);
+
+    @Query("SELECT lr FROM LeaveRequest lr " +
+            "JOIN lr.schedule s " +
+            "WHERE s.scheduleMonth = :scheduleMonth")
+    List<LeaveRequest> findAllByScheduleMonth(String scheduleMonth);
 }

--- a/src/main/java/com/burntoburn/easyshift/service/leave/LeaveRequestAdminService.java
+++ b/src/main/java/com/burntoburn/easyshift/service/leave/LeaveRequestAdminService.java
@@ -1,0 +1,18 @@
+package com.burntoburn.easyshift.service.leave;
+
+import com.burntoburn.easyshift.entity.leave.LeaveRequest;
+import java.time.LocalDate;
+import java.util.List;
+
+// 관리자 기능
+public interface LeaveRequestAdminService {
+
+    // 휴무 승인
+    LeaveRequest approveLeaveRequest(Long leaveRequestId);
+
+    // 휴무 거절
+    LeaveRequest rejectLeaveRequest(Long leaveRequestId);
+
+    // 한 달 단위로 휴뮤 조회
+    List<LeaveRequest> getLeaveRequestsByMonth(String scheduleMonth);
+}

--- a/src/main/java/com/burntoburn/easyshift/service/leave/LeaveRequestFactory.java
+++ b/src/main/java/com/burntoburn/easyshift/service/leave/LeaveRequestFactory.java
@@ -1,0 +1,33 @@
+package com.burntoburn.easyshift.service.leave;
+
+import com.burntoburn.easyshift.dto.schedule.req.LeaveRequestDto;
+import com.burntoburn.easyshift.entity.leave.LeaveRequest;
+import com.burntoburn.easyshift.entity.schedule.Schedule;
+import com.burntoburn.easyshift.entity.user.ApprovalStatus;
+import com.burntoburn.easyshift.entity.user.User;
+import java.time.LocalDate;
+import org.springframework.stereotype.Component;
+
+@Component
+public class LeaveRequestFactory {
+    public LeaveRequest createLeaveRequest(User user, Schedule schedule, LocalDate date){
+        return LeaveRequest.builder()
+                .user(user)
+                .date(date)
+                .approvalStatus(ApprovalStatus.PENDING)
+                .schedule(schedule)
+                .build();
+    }
+
+    public LeaveRequest updateLeaveRequest(LeaveRequest leaveRequest, LocalDate date){
+        return leaveRequest.updateDate(date);
+    }
+
+    public void approvedRequest(LeaveRequest leaveRequest){
+        leaveRequest.approvedRequest();
+    }
+
+    public void rejectRequest(LeaveRequest leaveRequest){
+        leaveRequest.rejectRequest();
+    }
+}

--- a/src/main/java/com/burntoburn/easyshift/service/leave/LeaveRequestWorkerService.java
+++ b/src/main/java/com/burntoburn/easyshift/service/leave/LeaveRequestWorkerService.java
@@ -1,0 +1,22 @@
+package com.burntoburn.easyshift.service.leave;
+
+import com.burntoburn.easyshift.dto.schedule.req.LeaveRequestDto;
+import com.burntoburn.easyshift.entity.leave.LeaveRequest;
+import java.util.List;
+
+public interface LeaveRequestWorkerService {
+    // 휴무일 생성
+    LeaveRequest createLeaveRequest(Long userId, LeaveRequestDto requestDto);
+
+    // 특정 ID 로 휴무일 조회
+    LeaveRequest getLeaveRequest(Long leaveRequestId);
+
+    // 특정 userId 로 휴무일 조회
+    List<LeaveRequest> getLeaveRequestsByUser(Long userId);
+
+    // 휴무일 생성
+    LeaveRequest updateLeaveRequest(Long leaveRequestId, LeaveRequestDto requestDto);
+
+    // 휴무일 삭제
+    void cancelLeaveRequest(Long leaveRequestId, Long userId);
+}

--- a/src/main/java/com/burntoburn/easyshift/service/leave/imp/LeaveRequestAdminServiceImp.java
+++ b/src/main/java/com/burntoburn/easyshift/service/leave/imp/LeaveRequestAdminServiceImp.java
@@ -1,0 +1,42 @@
+package com.burntoburn.easyshift.service.leave.imp;
+
+import com.burntoburn.easyshift.entity.leave.LeaveRequest;
+import com.burntoburn.easyshift.repository.leave.LeaveRequestRepository;
+import com.burntoburn.easyshift.repository.user.UserRepository;
+import com.burntoburn.easyshift.service.leave.LeaveRequestAdminService;
+import com.burntoburn.easyshift.service.leave.LeaveRequestFactory;
+import java.util.List;
+import java.util.NoSuchElementException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class LeaveRequestAdminServiceImp implements LeaveRequestAdminService {
+    private final LeaveRequestRepository leaveRequestRepository;
+    private final LeaveRequestFactory leaveRequestFactory;
+    private final UserRepository userRepository;
+
+
+    @Override
+    public LeaveRequest approveLeaveRequest(Long leaveRequestId) {
+        LeaveRequest leaveRequest = leaveRequestRepository.findById(leaveRequestId)
+                .orElseThrow(() -> new NoSuchElementException("not found leaveRequestId"));
+        leaveRequestFactory.approvedRequest(leaveRequest);
+
+        return leaveRequest;
+    }
+
+    @Override
+    public LeaveRequest rejectLeaveRequest(Long leaveRequestId) {
+        LeaveRequest leaveRequest = leaveRequestRepository.findById(leaveRequestId)
+                .orElseThrow(() -> new NoSuchElementException("not found leaveRequestId"));
+        leaveRequestFactory.rejectRequest(leaveRequest);
+        return leaveRequest;
+    }
+
+    @Override
+    public List<LeaveRequest> getLeaveRequestsByMonth(String scheduleMonth) {
+        return leaveRequestRepository.findAllByScheduleMonth(scheduleMonth);
+    }
+}

--- a/src/main/java/com/burntoburn/easyshift/service/leave/imp/LeaveRequestWorkerServiceImp.java
+++ b/src/main/java/com/burntoburn/easyshift/service/leave/imp/LeaveRequestWorkerServiceImp.java
@@ -1,0 +1,68 @@
+package com.burntoburn.easyshift.service.leave.imp;
+
+import com.burntoburn.easyshift.dto.schedule.req.LeaveRequestDto;
+import com.burntoburn.easyshift.entity.leave.LeaveRequest;
+import com.burntoburn.easyshift.entity.schedule.Schedule;
+import com.burntoburn.easyshift.entity.user.User;
+import com.burntoburn.easyshift.repository.leave.LeaveRequestRepository;
+import com.burntoburn.easyshift.repository.schedule.ScheduleRepository;
+import com.burntoburn.easyshift.repository.user.UserRepository;
+import com.burntoburn.easyshift.service.leave.LeaveRequestFactory;
+import com.burntoburn.easyshift.service.leave.LeaveRequestWorkerService;
+import java.util.List;
+import java.util.NoSuchElementException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class LeaveRequestWorkerServiceImp implements LeaveRequestWorkerService {
+    private final LeaveRequestRepository leaveRequestRepository;
+    private final ScheduleRepository scheduleRepository;
+    private final UserRepository userRepository;
+    private final LeaveRequestFactory leaveRequestFactory;
+
+    @Override
+    public LeaveRequest createLeaveRequest(Long userId, LeaveRequestDto requestDto) {
+        // user 확인
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new NoSuchElementException("user 존재하지 않음"));
+
+        // Schedule 확인
+        Schedule schedule = scheduleRepository.findById(requestDto.getScheduleId())
+                .orElseThrow(() -> new NoSuchElementException("getScheduleId fails"));
+
+        LeaveRequest leaveRequest = leaveRequestFactory.createLeaveRequest(user, schedule, requestDto.getDate());
+        leaveRequestRepository.save(leaveRequest);
+        return leaveRequest;
+    }
+
+    @Override
+    public LeaveRequest getLeaveRequest(Long leaveRequestId) {
+        return leaveRequestRepository.findById(leaveRequestId)
+                .orElseThrow(()->new NoSuchElementException("leaveRequestId 존재하지 않음"));
+    }
+
+    @Override
+    public List<LeaveRequest> getLeaveRequestsByUser(Long userId) {
+        return leaveRequestRepository.findAllByUserId(userId);
+    }
+
+    @Transactional
+    @Override
+    public LeaveRequest updateLeaveRequest(Long leaveRequestId, LeaveRequestDto requestDto) {
+        LeaveRequest leaveRequest = getLeaveRequest(leaveRequestId);
+
+        // 팩토리 패턴으로 수정
+        leaveRequestFactory.updateLeaveRequest(leaveRequest, requestDto.getDate());
+
+        return leaveRequestRepository.save(leaveRequest); // [명시적 저장] JPA 의 변경 감지로 수정 예정
+    }
+
+    @Override
+    public void cancelLeaveRequest(Long leaveRequestId, Long userId) {
+        getLeaveRequest(leaveRequestId);
+        leaveRequestRepository.deleteById(leaveRequestId);
+    }
+}

--- a/src/test/java/com/burntoburn/easyshift/service/leave/imp/LeaveRequestAdminServiceImpTest.java
+++ b/src/test/java/com/burntoburn/easyshift/service/leave/imp/LeaveRequestAdminServiceImpTest.java
@@ -1,0 +1,113 @@
+package com.burntoburn.easyshift.service.leave.imp;
+
+import com.burntoburn.easyshift.entity.leave.LeaveRequest;
+import com.burntoburn.easyshift.entity.user.ApprovalStatus;
+import com.burntoburn.easyshift.repository.leave.LeaveRequestRepository;
+import com.burntoburn.easyshift.service.leave.LeaveRequestAdminService;
+import com.burntoburn.easyshift.service.leave.LeaveRequestFactory;
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Optional;
+import java.util.NoSuchElementException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+@SpringBootTest
+class LeaveRequestAdminServiceImpTest {
+
+    @Autowired
+    private LeaveRequestAdminService leaveRequestAdminService;
+
+    @MockitoBean
+    private LeaveRequestRepository leaveRequestRepository;
+
+    @MockitoBean
+    private LeaveRequestFactory leaveRequestFactory;
+
+    private LeaveRequest leaveRequest;
+
+    @BeforeEach
+    void setUp() {
+        // 더미 휴가 신청 생성
+        leaveRequest = LeaveRequest.builder()
+                .id(1L)
+                .date(LocalDate.of(2024, 3, 15))
+                .approvalStatus(ApprovalStatus.PENDING)
+                .build();
+    }
+
+    @Test
+    @DisplayName("휴가 신청 승인 테스트")
+    void approveLeaveRequest() {
+        // Given
+        when(leaveRequestRepository.findById(1L)).thenReturn(Optional.of(leaveRequest));
+        doNothing().when(leaveRequestFactory).approvedRequest(leaveRequest);
+
+        // When
+        LeaveRequest result = leaveRequestAdminService.approveLeaveRequest(1L);
+
+        // Then
+        assertNotNull(result);
+        verify(leaveRequestFactory, times(1)).approvedRequest(leaveRequest);
+        verify(leaveRequestRepository, times(1)).findById(1L);
+    }
+
+    @Test
+    @DisplayName("휴가 신청 거절 테스트")
+    void rejectLeaveRequest() {
+        // Given
+        when(leaveRequestRepository.findById(1L)).thenReturn(Optional.of(leaveRequest));
+        doNothing().when(leaveRequestFactory).rejectRequest(leaveRequest);
+
+        // When
+        LeaveRequest result = leaveRequestAdminService.rejectLeaveRequest(1L);
+
+        // Then
+        assertNotNull(result);
+        verify(leaveRequestFactory, times(1)).rejectRequest(leaveRequest);
+        verify(leaveRequestRepository, times(1)).findById(1L);
+    }
+
+    @Test
+    @DisplayName("특정 월의 휴가 신청 조회 테스트")
+    void getLeaveRequestsByMonth() {
+        // Given
+        String scheduleMonth = "2024-03";
+        when(leaveRequestRepository.findAllByScheduleMonth(scheduleMonth)).thenReturn(List.of(leaveRequest));
+
+        // When
+        List<LeaveRequest> result = leaveRequestAdminService.getLeaveRequestsByMonth(scheduleMonth);
+
+        // Then
+        assertNotNull(result);
+        assertEquals(1, result.size());
+        verify(leaveRequestRepository, times(1)).findAllByScheduleMonth(scheduleMonth);
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 휴가 신청 승인 시 예외 발생")
+    void approveLeaveRequest_NotFound() {
+        // Given
+        when(leaveRequestRepository.findById(2L)).thenReturn(Optional.empty());
+
+        // When & Then
+        assertThrows(NoSuchElementException.class, () -> leaveRequestAdminService.approveLeaveRequest(2L));
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 휴가 신청 거절 시 예외 발생")
+    void rejectLeaveRequest_NotFound() {
+        // Given
+        when(leaveRequestRepository.findById(2L)).thenReturn(Optional.empty());
+
+        // When & Then
+        assertThrows(NoSuchElementException.class, () -> leaveRequestAdminService.rejectLeaveRequest(2L));
+    }
+}

--- a/src/test/java/com/burntoburn/easyshift/service/leave/imp/LeaveRequestWorkerServiceImpTest.java
+++ b/src/test/java/com/burntoburn/easyshift/service/leave/imp/LeaveRequestWorkerServiceImpTest.java
@@ -1,0 +1,183 @@
+package com.burntoburn.easyshift.service.leave.imp;
+
+import com.burntoburn.easyshift.dto.schedule.req.LeaveRequestDto;
+import com.burntoburn.easyshift.entity.leave.LeaveRequest;
+import com.burntoburn.easyshift.entity.schedule.Schedule;
+import com.burntoburn.easyshift.entity.user.User;
+import com.burntoburn.easyshift.repository.leave.LeaveRequestRepository;
+import com.burntoburn.easyshift.repository.schedule.ScheduleRepository;
+import com.burntoburn.easyshift.repository.user.UserRepository;
+import com.burntoburn.easyshift.service.leave.LeaveRequestFactory;
+import com.burntoburn.easyshift.service.leave.LeaveRequestWorkerService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.NoSuchElementException;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+@SpringBootTest
+class LeaveRequestWorkerServiceImpTest {
+
+    @Autowired
+    private LeaveRequestWorkerService leaveRequestWorkerService;
+
+    @MockitoBean
+    private LeaveRequestRepository leaveRequestRepository;
+
+    @MockitoBean
+    private ScheduleRepository scheduleRepository;
+
+    @MockitoBean
+    private UserRepository userRepository;
+
+    @MockitoBean
+    private LeaveRequestFactory leaveRequestFactory;
+
+    private User user;
+    private Schedule schedule;
+    private LeaveRequest leaveRequest;
+
+    @BeforeEach
+    void setUp() {
+        user = User.builder()
+                .id(1L)
+                .build();
+
+        schedule = Schedule.builder()
+                .id(1L)
+                .build();
+
+        leaveRequest = LeaveRequest.builder()
+                .id(1L)
+                .user(user)
+                .schedule(schedule)
+                .date(LocalDate.of(2024, 3, 10))
+                .build();
+    }
+
+    @Test
+    @DisplayName("휴무 신청 생성 테스트")
+    void createLeaveRequest() {
+        // Given
+        LeaveRequestDto requestDto = new LeaveRequestDto(schedule.getId(), LocalDate.of(2024, 3, 10));
+
+        when(userRepository.findById(1L)).thenReturn(Optional.of(user));
+        when(scheduleRepository.findById(1L)).thenReturn(Optional.of(schedule));
+        when(leaveRequestFactory.createLeaveRequest(user, schedule, requestDto.getDate())).thenReturn(leaveRequest);
+        when(leaveRequestRepository.save(any(LeaveRequest.class))).thenReturn(leaveRequest);
+
+        // When
+        LeaveRequest createdLeaveRequest = leaveRequestWorkerService.createLeaveRequest(1L, requestDto);
+
+        // Then
+        assertNotNull(createdLeaveRequest);
+        assertEquals(user, createdLeaveRequest.getUser());
+        assertEquals(schedule, createdLeaveRequest.getSchedule());
+        assertEquals(requestDto.getDate(), createdLeaveRequest.getDate());
+
+        verify(leaveRequestRepository, times(1)).save(any(LeaveRequest.class));
+    }
+
+    @Test
+    @DisplayName("휴무 신청 단건 조회 테스트")
+    void getLeaveRequest() {
+        // Given
+        when(leaveRequestRepository.findById(1L)).thenReturn(Optional.of(leaveRequest));
+
+        // When
+        LeaveRequest foundLeaveRequest = leaveRequestWorkerService.getLeaveRequest(1L);
+
+        // Then
+        assertNotNull(foundLeaveRequest);
+        assertEquals(leaveRequest.getId(), foundLeaveRequest.getId());
+
+        verify(leaveRequestRepository, times(1)).findById(1L);
+    }
+
+    @Test
+    @DisplayName("사용자의 모든 휴무 신청 조회 테스트")
+    void getLeaveRequestsByUser() {
+        // Given
+        when(leaveRequestRepository.findAllByUserId(1L)).thenReturn(List.of(leaveRequest));
+
+        // When
+        List<LeaveRequest> leaveRequests = leaveRequestWorkerService.getLeaveRequestsByUser(1L);
+
+        // Then
+        assertNotNull(leaveRequests);
+        assertEquals(1, leaveRequests.size());
+        assertEquals(leaveRequest.getId(), leaveRequests.get(0).getId());
+
+        verify(leaveRequestRepository, times(1)).findAllByUserId(1L);
+    }
+
+    @Test
+    @DisplayName("휴무 신청 업데이트 테스트 - 명시적 저장 방식")
+    void updateLeaveRequest() {
+        // Given
+        LocalDate newDate = LocalDate.of(2024, 3, 15);
+        LeaveRequest updatedLeaveRequest = LeaveRequest.builder()
+                .id(1L)
+                .user(user)
+                .schedule(schedule)
+                .date(newDate)
+                .build();
+
+        when(leaveRequestRepository.findById(1L)).thenReturn(Optional.of(leaveRequest));
+        when(leaveRequestRepository.save(any(LeaveRequest.class))).thenReturn(updatedLeaveRequest);
+
+        // When
+        LeaveRequest result = leaveRequestWorkerService.updateLeaveRequest(1L, new LeaveRequestDto(1L, newDate));
+
+        // Then
+        assertNotNull(result, "업데이트된 휴무 요청이 null이면 안 됩니다.");
+        assertEquals(newDate, result.getDate(), "휴무 요청 날짜가 변경되지 않았습니다.");
+
+        // ✅ save()가 정확히 호출되었는지 검증
+        verify(leaveRequestRepository, times(1)).save(any(LeaveRequest.class));
+    }
+
+
+    @Test
+    @DisplayName("휴무 신청 취소 테스트")
+    void cancelLeaveRequest() {
+        // Given
+        when(leaveRequestRepository.findById(1L)).thenReturn(Optional.of(leaveRequest));
+        doNothing().when(leaveRequestRepository).deleteById(1L);
+
+        // When
+        leaveRequestWorkerService.cancelLeaveRequest(1L, 1L);
+
+        // Then
+        verify(leaveRequestRepository, times(1)).deleteById(1L);
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 휴무 신청 조회 시 예외 발생")
+    void getLeaveRequest_NotFound() {
+        // Given
+        when(leaveRequestRepository.findById(1L)).thenReturn(Optional.empty());
+
+        // When & Then
+        assertThrows(NoSuchElementException.class, () -> leaveRequestWorkerService.getLeaveRequest(1L));
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 휴무 신청 삭제 시 예외 발생")
+    void cancelLeaveRequest_NotFound() {
+        // Given
+        when(leaveRequestRepository.findById(1L)).thenReturn(Optional.empty());
+
+        // When & Then
+        assertThrows(NoSuchElementException.class, () -> leaveRequestWorkerService.cancelLeaveRequest(1L, 1L));
+    }
+}


### PR DESCRIPTION
## 작업 내용
### ✅ LeaveRequestService 기능 구현
- 휴무 신청(LeaveRequest) CRUD 기능 개발
- 사용자(User)는 자신의 휴무 요청을 생성, 수정, 취소 가능
- 관리자는 휴무 요청 승인 및 거절 가능
- 한 달 단위로 휴무 신청 목록 조회 기능 추가

### ✅ LeaveRequestWorkerService / LeaveRequestAdminService 분리
- **Worker 기능**: 사용자 휴무 신청 및 조회, 취소 담당
- **Admin 기능**: 휴무 요청 승인/거절 담당

### ✅ 단위 테스트 추가
- **Mockito 기반 단위 테스트 작성**
  - `LeaveRequestWorkerServiceImpTest`
  - `LeaveRequestAdminServiceImpTest`
- `@SpringBootTest`, `@MockitoBean` 활용하여 서비스 로직 검증

<img width="801" alt="image" src="https://github.com/user-attachments/assets/48803784-5367-42a4-a047-a836f8bde4ad" />
<img width="801" alt="image" src="https://github.com/user-attachments/assets/a38e40ba-f1eb-453f-bcfc-f20e53d4e820" />

