### PR TITLE
refactor: 유저에 해당하는 매장 반환시 형식 변경

### DIFF
--- a/src/main/java/com/burntoburn/easyshift/controller/StoreController.java
+++ b/src/main/java/com/burntoburn/easyshift/controller/StoreController.java
@@ -1,6 +1,7 @@
 package com.burntoburn.easyshift.controller;
 
 import com.burntoburn.easyshift.dto.store.req.StoreCreateRequest;
+import com.burntoburn.easyshift.dto.store.res.StoreDto;
 import com.burntoburn.easyshift.dto.store.res.StoreScheduleResponseDTO;
 import com.burntoburn.easyshift.entity.store.Store;
 import com.burntoburn.easyshift.service.StoreService;
@@ -32,8 +33,8 @@ public class StoreController {
     }
 
     @GetMapping("/by-user")
-    public ResponseEntity<List<String>> getStoreNamesByUserId(@RequestParam("userId") Long userId) {
-        List<String> storeNames = storeService.getStoreNamesByUserId(userId);
+    public ResponseEntity<List<StoreDto>> getStoreNamesByUserId(@RequestParam("userId") Long userId) {
+        List<StoreDto> storeNames = storeService.getStoreNamesByUserId(userId);
         return ResponseEntity.ok(storeNames);
     }
 

--- a/src/main/java/com/burntoburn/easyshift/dto/store/res/StoreDto.java
+++ b/src/main/java/com/burntoburn/easyshift/dto/store/res/StoreDto.java
@@ -1,0 +1,14 @@
+package com.burntoburn.easyshift.dto.store.res;
+
+import lombok.Getter;
+
+@Getter
+public class StoreDto {
+    private Long id;
+    private String name;
+
+    public StoreDto(Long id, String name){
+        this.id = id;
+        this.name = name;
+    }
+}

--- a/src/main/java/com/burntoburn/easyshift/service/StoreService.java
+++ b/src/main/java/com/burntoburn/easyshift/service/StoreService.java
@@ -8,6 +8,7 @@ import com.burntoburn.easyshift.dto.shift.res.ShiftDateDTO;
 import com.burntoburn.easyshift.dto.shift.res.ShiftGroupDTO;
 import com.burntoburn.easyshift.dto.shift.res.ShiftKey;
 import com.burntoburn.easyshift.dto.store.req.StoreCreateRequest;
+import com.burntoburn.easyshift.dto.store.res.StoreDto;
 import com.burntoburn.easyshift.dto.store.res.StoreScheduleResponseDTO;
 import com.burntoburn.easyshift.entity.schedule.Schedule;
 import com.burntoburn.easyshift.entity.schedule.Shift;
@@ -57,14 +58,17 @@ public class StoreService {
         storeRepository.delete(store);
     }
 
-    public List<String> getStoreNamesByUserId(Long userId) {
+    public List<StoreDto> getStoreNamesByUserId(Long userId) {
         List<UserStore> userStores = userStoreRepository.findAllByUserId(userId);
         if (userStores.isEmpty()) {
             throw new RuntimeException("해당 사용자와 연결된 매장이 없습니다.");
         }
 
         return userStores.stream()
-                .map(userStore -> userStore.getStore().getStoreName())
+                .map(userStore -> {
+                    Store store = userStore.getStore();
+                    return new StoreDto(store.getId(), store.getStoreName());
+                })
                 .collect(Collectors.toList());
     }
 

--- a/src/test/java/com/burntoburn/easyshift/store/StoresGetByUserIdTest.java
+++ b/src/test/java/com/burntoburn/easyshift/store/StoresGetByUserIdTest.java
@@ -1,6 +1,7 @@
 package com.burntoburn.easyshift.store;
 
 import com.burntoburn.easyshift.config.jwt.TokenProvider;
+import com.burntoburn.easyshift.dto.store.res.StoreDto;
 import com.burntoburn.easyshift.entity.store.Store;
 import com.burntoburn.easyshift.entity.store.UserStore;
 import com.burntoburn.easyshift.repository.schedule.ScheduleRepository;
@@ -65,7 +66,7 @@ public class StoresGetByUserIdTest {
         when(userStoreRepository.findAllByUserId(userId)).thenReturn(userStores);
 
         // then
-        List<String> storeNames = storeService.getStoreNamesByUserId(userId);
+        List<StoreDto> storeNames = storeService.getStoreNamesByUserId(userId);
         assertNotNull(storeNames);
         assertEquals(2, storeNames.size());
         assertTrue(storeNames.contains("Store A"));


### PR DESCRIPTION
```json
Status-Code: 200 OK

[
  { "id": 1, "name": "Store One" },
  { "id": 2, "name": "Store Two" }
]
```

**동작 설명:**

- 요청받은 `userId`로 `userStoreRepository.findAllByUserId(userId)`를 호출하여 사용자가 연결된 매장들을 조회합니다.
- 매장이 존재할 경우 각 매장의 ID와 이름을 포함하는 `StoreDto` 객체로 매핑되어 리스트로 반환됩니다.