### PR TITLE
feat: 매장 스케줄 템플릿 CRUD API 구현

### DIFF
--- a/src/main/java/com/burntoburn/easyshift/controller/template/ScheduleTemplateController.java
+++ b/src/main/java/com/burntoburn/easyshift/controller/template/ScheduleTemplateController.java
@@ -18,7 +18,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/api/schedule-templates")
+@RequestMapping("/api")
 public class ScheduleTemplateController {
     private final ScheduleTemplateService scheduleTemplateService;
 
@@ -28,7 +28,7 @@ public class ScheduleTemplateController {
      * @param request 생성할 스케줄 템플릿 정보 (RequestBody)
      * @return 생성된 스케줄 템플릿 정보를 포함한 DTO 응답
      */
-    @PostMapping("/{storeId}")
+    @PostMapping("/stores/{storeId}/schedule-templates")
     public ResponseEntity<ScheduleTemplateResponse> createScheduleTemplate(
             @PathVariable Long storeId,
             @RequestBody ScheduleTemplateRequest request) {
@@ -41,7 +41,7 @@ public class ScheduleTemplateController {
      * @param @param storeId 매장 ID
      * @return 해당 매장의 스케줄 템플릿 리스트 (DTO 변환 후 반환)
      **/
-    @GetMapping("/{storeId}")
+    @GetMapping("/stores/{store_id}/schedule-templates")
     public ResponseEntity<AllScheduleTemplateResponse> getScheduleTemplate(@PathVariable Long storeId) {
         AllScheduleTemplateResponse allScheduleTemplatesByStore = scheduleTemplateService
                 .getAllScheduleTemplatesByStore(storeId);
@@ -53,7 +53,7 @@ public class ScheduleTemplateController {
      * @param scheduleTemplateId 삭제할 스케줄 템플릿 ID (PathVariable)*
      * @return 삭제 후 204 No Content 응답 반환
     **/
-    @DeleteMapping("/{scheduleTemplateId}")
+    @DeleteMapping("/schedule-templates/{scheduleTemplateId}")
     public ResponseEntity<Void> deleteScheduleTemplate(@PathVariable Long scheduleTemplateId){
         scheduleTemplateService.deleteScheduleTemplate(scheduleTemplateId);
         return ResponseEntity.noContent().build();

--- a/src/main/java/com/burntoburn/easyshift/controller/template/ScheduleTemplateController.java
+++ b/src/main/java/com/burntoburn/easyshift/controller/template/ScheduleTemplateController.java
@@ -1,6 +1,7 @@
 package com.burntoburn.easyshift.controller.template;
 
 import com.burntoburn.easyshift.dto.template.req.ScheduleTemplateRequest;
+import com.burntoburn.easyshift.dto.template.res.ScheduleTemplateResponse;
 import com.burntoburn.easyshift.entity.templates.ScheduleTemplate;
 import com.burntoburn.easyshift.service.templates.ScheduleTemplateService;
 import lombok.RequiredArgsConstructor;
@@ -19,12 +20,19 @@ public class ScheduleTemplateController {
 
     /**
      * 스케줄 템플릿 생성 API
+     * @param storeId 매장 ID (PathVariable)
+     * @param request 생성할 스케줄 템플릿 정보 (RequestBody)
+     * @return 생성된 스케줄 템플릿 정보를 포함한 DTO 응답
      */
     @PostMapping("/{storeId}")
-    public ResponseEntity<ScheduleTemplate> createScheduleTemplate(
+    public ResponseEntity<ScheduleTemplateResponse> createScheduleTemplate(
             @PathVariable Long storeId,
             @RequestBody ScheduleTemplateRequest request) {
         ScheduleTemplate createdTemplate = scheduleTemplateService.createScheduleTemplate(storeId, request);
-        return ResponseEntity.ok(createdTemplate);
+        ScheduleTemplateResponse dto = createdTemplate.toDTO();
+        return ResponseEntity.ok(dto);
     }
+
+
+
 }

--- a/src/main/java/com/burntoburn/easyshift/controller/template/ScheduleTemplateController.java
+++ b/src/main/java/com/burntoburn/easyshift/controller/template/ScheduleTemplateController.java
@@ -1,6 +1,6 @@
 package com.burntoburn.easyshift.controller.template;
 
-import com.burntoburn.easyshift.dto.schedule.req.scheduleTemplate.ScheduleTemplateRequest;
+import com.burntoburn.easyshift.dto.template.req.ScheduleTemplateRequest;
 import com.burntoburn.easyshift.entity.templates.ScheduleTemplate;
 import com.burntoburn.easyshift.service.templates.ScheduleTemplateService;
 import lombok.RequiredArgsConstructor;

--- a/src/main/java/com/burntoburn/easyshift/controller/template/ScheduleTemplateController.java
+++ b/src/main/java/com/burntoburn/easyshift/controller/template/ScheduleTemplateController.java
@@ -1,11 +1,15 @@
 package com.burntoburn.easyshift.controller.template;
 
 import com.burntoburn.easyshift.dto.template.req.ScheduleTemplateRequest;
+import com.burntoburn.easyshift.dto.template.res.AllScheduleTemplateResponse;
 import com.burntoburn.easyshift.dto.template.res.ScheduleTemplateResponse;
 import com.burntoburn.easyshift.entity.templates.ScheduleTemplate;
 import com.burntoburn.easyshift.service.templates.ScheduleTemplateService;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -32,6 +36,30 @@ public class ScheduleTemplateController {
         ScheduleTemplateResponse dto = createdTemplate.toDTO();
         return ResponseEntity.ok(dto);
     }
+
+    /**
+     * @param @param storeId 매장 ID
+     * @return 해당 매장의 스케줄 템플릿 리스트 (DTO 변환 후 반환)
+     **/
+    @GetMapping("/{storeId}")
+    public ResponseEntity<AllScheduleTemplateResponse> getScheduleTemplate(@PathVariable Long storeId) {
+        AllScheduleTemplateResponse allScheduleTemplatesByStore = scheduleTemplateService
+                .getAllScheduleTemplatesByStore(storeId);
+
+        return ResponseEntity.ok(allScheduleTemplatesByStore);
+    }
+
+    /**
+     * @param scheduleTemplateId 삭제할 스케줄 템플릿 ID (PathVariable)*
+     * @return 삭제 후 204 No Content 응답 반환
+    **/
+    @DeleteMapping("/{scheduleTemplateId}")
+    public ResponseEntity<Void> deleteScheduleTemplate(@PathVariable Long scheduleTemplateId){
+        scheduleTemplateService.deleteScheduleTemplate(scheduleTemplateId);
+        return ResponseEntity.noContent().build();
+    }
+
+
 
 
 

--- a/src/main/java/com/burntoburn/easyshift/controller/template/ScheduleTemplateController.java
+++ b/src/main/java/com/burntoburn/easyshift/controller/template/ScheduleTemplateController.java
@@ -1,4 +1,4 @@
-package com.burntoburn.easyshift.controller.templateCt;
+package com.burntoburn.easyshift.controller.template;
 
 import com.burntoburn.easyshift.dto.schedule.req.scheduleTemplate.ScheduleTemplateRequest;
 import com.burntoburn.easyshift.entity.templates.ScheduleTemplate;

--- a/src/main/java/com/burntoburn/easyshift/controller/template/ScheduleTemplateController.java
+++ b/src/main/java/com/burntoburn/easyshift/controller/template/ScheduleTemplateController.java
@@ -41,7 +41,7 @@ public class ScheduleTemplateController {
      * @param @param storeId 매장 ID
      * @return 해당 매장의 스케줄 템플릿 리스트 (DTO 변환 후 반환)
      **/
-    @GetMapping("/stores/{store_id}/schedule-templates")
+    @GetMapping("/stores/{storeId}/schedule-templates")
     public ResponseEntity<AllScheduleTemplateResponse> getScheduleTemplate(@PathVariable Long storeId) {
         AllScheduleTemplateResponse allScheduleTemplatesByStore = scheduleTemplateService
                 .getAllScheduleTemplatesByStore(storeId);

--- a/src/main/java/com/burntoburn/easyshift/dto/leave/req/LeaveRequestDto.java
+++ b/src/main/java/com/burntoburn/easyshift/dto/leave/req/LeaveRequestDto.java
@@ -1,4 +1,4 @@
-package com.burntoburn.easyshift.dto.schedule.req;
+package com.burntoburn.easyshift.dto.leave.req;
 
 import java.time.LocalDate;
 import lombok.AllArgsConstructor;

--- a/src/main/java/com/burntoburn/easyshift/dto/schedule/res/ScheduleTemplateResponse.java
+++ b/src/main/java/com/burntoburn/easyshift/dto/schedule/res/ScheduleTemplateResponse.java
@@ -1,4 +1,0 @@
-package com.burntoburn.easyshift.dto.schedule.res;
-
-public class ScheduleTemplateResponse {
-}

--- a/src/main/java/com/burntoburn/easyshift/dto/template/req/ScheduleTemplateRequest.java
+++ b/src/main/java/com/burntoburn/easyshift/dto/template/req/ScheduleTemplateRequest.java
@@ -1,4 +1,4 @@
-package com.burntoburn.easyshift.dto.schedule.req.scheduleTemplate;
+package com.burntoburn.easyshift.dto.template.req;
 
 import java.util.List;
 import lombok.AllArgsConstructor;

--- a/src/main/java/com/burntoburn/easyshift/dto/template/req/ShiftTemplateRequest.java
+++ b/src/main/java/com/burntoburn/easyshift/dto/template/req/ShiftTemplateRequest.java
@@ -11,7 +11,7 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 @Builder
 public class ShiftTemplateRequest {
-    private String shiftTemplateName;
+    private String shiftName;
     private LocalTime startTime;
     private LocalTime endTime;
 }

--- a/src/main/java/com/burntoburn/easyshift/dto/template/req/ShiftTemplateRequest.java
+++ b/src/main/java/com/burntoburn/easyshift/dto/template/req/ShiftTemplateRequest.java
@@ -1,4 +1,4 @@
-package com.burntoburn.easyshift.dto.schedule.req.scheduleTemplate;
+package com.burntoburn.easyshift.dto.template.req;
 
 import java.time.LocalTime;
 import lombok.AllArgsConstructor;

--- a/src/main/java/com/burntoburn/easyshift/dto/template/res/AllScheduleTemplateResponse.java
+++ b/src/main/java/com/burntoburn/easyshift/dto/template/res/AllScheduleTemplateResponse.java
@@ -1,0 +1,24 @@
+package com.burntoburn.easyshift.dto.template.res;
+
+import com.burntoburn.easyshift.entity.templates.ScheduleTemplate;
+import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class AllScheduleTemplateResponse {
+    private List<ScheduleTemplateResponse> scheduleTemplateResponses;
+
+    // ✅ 리스트 변환을 위한 정적 메서드 추가
+    public static AllScheduleTemplateResponse fromEntityList(List<ScheduleTemplate> scheduleTemplates) {
+        List<ScheduleTemplateResponse> responseList = scheduleTemplates.stream()
+                .map(ScheduleTemplate::toDTO) // 각 엔티티를 DTO로 변환
+                .toList();
+        return new AllScheduleTemplateResponse(responseList);
+    }
+}

--- a/src/main/java/com/burntoburn/easyshift/dto/template/res/ScheduleTemplateResponse.java
+++ b/src/main/java/com/burntoburn/easyshift/dto/template/res/ScheduleTemplateResponse.java
@@ -1,0 +1,18 @@
+package com.burntoburn.easyshift.dto.template.res;
+
+import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class ScheduleTemplateResponse {
+    private Long id;
+    private String scheduleTemplateName;
+    private Long storeId;
+    private List<ShiftTemplateResponse> shiftTemplates;
+}

--- a/src/main/java/com/burntoburn/easyshift/dto/template/res/ShiftTemplateResponse.java
+++ b/src/main/java/com/burntoburn/easyshift/dto/template/res/ShiftTemplateResponse.java
@@ -1,0 +1,28 @@
+package com.burntoburn.easyshift.dto.template.res;
+
+import com.burntoburn.easyshift.entity.templates.ShiftTemplate;
+import java.time.LocalTime;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class ShiftTemplateResponse {
+    private Long id;
+    private String shiftName;
+    private LocalTime startTime;
+    private LocalTime endTime;
+
+    public static ShiftTemplateResponse fromEntity(ShiftTemplate shiftTemplate) {
+        return ShiftTemplateResponse.builder()
+                .id(shiftTemplate.getId())
+                .shiftName(shiftTemplate.getShiftTemplateName())
+                .startTime(shiftTemplate.getStartTime())
+                .endTime(shiftTemplate.getEndTime())
+                .build();
+    }
+}

--- a/src/main/java/com/burntoburn/easyshift/entity/templates/ScheduleTemplate.java
+++ b/src/main/java/com/burntoburn/easyshift/entity/templates/ScheduleTemplate.java
@@ -1,5 +1,7 @@
 package com.burntoburn.easyshift.entity.templates;
 
+import com.burntoburn.easyshift.dto.template.res.ScheduleTemplateResponse;
+import com.burntoburn.easyshift.dto.template.res.ShiftTemplateResponse;
 import com.burntoburn.easyshift.entity.store.Store;
 import com.burntoburn.easyshift.entity.templates.collection.ShiftTemplates;
 import jakarta.persistence.*;
@@ -36,4 +38,17 @@ public class ScheduleTemplate {
         this.scheduleTemplateName = scheduleTemplateName;
         this.shiftTemplates.update(updatedShiftTemplates); // ✅ 일급 컬렉션 내부에서 관리
     }
+
+    public ScheduleTemplateResponse toDTO() {
+        return ScheduleTemplateResponse.builder()
+                .id(this.id)
+                .scheduleTemplateName(this.scheduleTemplateName)
+                .storeId(this.store.getId()) // ✅ Lazy Loading 문제 방지: ID만 반환
+                .shiftTemplates(this.shiftTemplates.getList().stream()
+                        .map(ShiftTemplateResponse::fromEntity) // ✅ ShiftTemplate 변환
+                        .toList())
+                .build();
+    }
+
+
 }

--- a/src/main/java/com/burntoburn/easyshift/repository/schedule/ScheduleTemplateRepository.java
+++ b/src/main/java/com/burntoburn/easyshift/repository/schedule/ScheduleTemplateRepository.java
@@ -8,5 +8,5 @@ import org.springframework.stereotype.Repository;
 
 @Repository
 public interface ScheduleTemplateRepository extends JpaRepository<ScheduleTemplate, Long> {
-    Optional<List<ScheduleTemplate>> findAllByStoreId(Long storeId);
+   List<ScheduleTemplate> findAllByStoreId(Long storeId);
 }

--- a/src/main/java/com/burntoburn/easyshift/repository/schedule/ScheduleTemplateRepository.java
+++ b/src/main/java/com/burntoburn/easyshift/repository/schedule/ScheduleTemplateRepository.java
@@ -1,11 +1,12 @@
 package com.burntoburn.easyshift.repository.schedule;
 
 import com.burntoburn.easyshift.entity.templates.ScheduleTemplate;
+import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface ScheduleTemplateRepository extends JpaRepository<ScheduleTemplate, Long> {
-    Optional<ScheduleTemplate> getScheduleTemplateById(Long id);
+    Optional<List<ScheduleTemplate>> findAllByStoreId(Long storeId);
 }

--- a/src/main/java/com/burntoburn/easyshift/service/leave/LeaveRequestFactory.java
+++ b/src/main/java/com/burntoburn/easyshift/service/leave/LeaveRequestFactory.java
@@ -1,6 +1,5 @@
 package com.burntoburn.easyshift.service.leave;
 
-import com.burntoburn.easyshift.dto.schedule.req.LeaveRequestDto;
 import com.burntoburn.easyshift.entity.leave.LeaveRequest;
 import com.burntoburn.easyshift.entity.schedule.Schedule;
 import com.burntoburn.easyshift.entity.user.ApprovalStatus;

--- a/src/main/java/com/burntoburn/easyshift/service/leave/LeaveRequestWorkerService.java
+++ b/src/main/java/com/burntoburn/easyshift/service/leave/LeaveRequestWorkerService.java
@@ -1,6 +1,6 @@
 package com.burntoburn.easyshift.service.leave;
 
-import com.burntoburn.easyshift.dto.schedule.req.LeaveRequestDto;
+import com.burntoburn.easyshift.dto.leave.req.LeaveRequestDto;
 import com.burntoburn.easyshift.entity.leave.LeaveRequest;
 import java.util.List;
 

--- a/src/main/java/com/burntoburn/easyshift/service/leave/imp/LeaveRequestWorkerServiceImp.java
+++ b/src/main/java/com/burntoburn/easyshift/service/leave/imp/LeaveRequestWorkerServiceImp.java
@@ -1,6 +1,6 @@
 package com.burntoburn.easyshift.service.leave.imp;
 
-import com.burntoburn.easyshift.dto.schedule.req.LeaveRequestDto;
+import com.burntoburn.easyshift.dto.leave.req.LeaveRequestDto;
 import com.burntoburn.easyshift.entity.leave.LeaveRequest;
 import com.burntoburn.easyshift.entity.schedule.Schedule;
 import com.burntoburn.easyshift.entity.user.User;

--- a/src/main/java/com/burntoburn/easyshift/service/templates/ScheduleTemplateFactory.java
+++ b/src/main/java/com/burntoburn/easyshift/service/templates/ScheduleTemplateFactory.java
@@ -1,7 +1,7 @@
 package com.burntoburn.easyshift.service.templates;
 
-import com.burntoburn.easyshift.dto.schedule.req.scheduleTemplate.ScheduleTemplateRequest;
-import com.burntoburn.easyshift.dto.schedule.req.scheduleTemplate.ShiftTemplateRequest;
+import com.burntoburn.easyshift.dto.template.req.ScheduleTemplateRequest;
+import com.burntoburn.easyshift.dto.template.req.ShiftTemplateRequest;
 import com.burntoburn.easyshift.entity.templates.ScheduleTemplate;
 import com.burntoburn.easyshift.entity.templates.ShiftTemplate;
 import com.burntoburn.easyshift.entity.templates.collection.ShiftTemplates;

--- a/src/main/java/com/burntoburn/easyshift/service/templates/ScheduleTemplateFactory.java
+++ b/src/main/java/com/burntoburn/easyshift/service/templates/ScheduleTemplateFactory.java
@@ -36,7 +36,7 @@ public class ScheduleTemplateFactory {
                 .orElse(Collections.emptyList()) // null 방지
                 .stream()
                 .map(shiftRequest -> ShiftTemplate.builder()
-                        .shiftTemplateName(shiftRequest.getShiftTemplateName())
+                        .shiftTemplateName(shiftRequest.getShiftName())
                         .startTime(shiftRequest.getStartTime())
                         .endTime(shiftRequest.getEndTime())
                         .build())

--- a/src/main/java/com/burntoburn/easyshift/service/templates/ScheduleTemplateService.java
+++ b/src/main/java/com/burntoburn/easyshift/service/templates/ScheduleTemplateService.java
@@ -1,6 +1,6 @@
 package com.burntoburn.easyshift.service.templates;
 
-import com.burntoburn.easyshift.dto.schedule.req.scheduleTemplate.ScheduleTemplateRequest;
+import com.burntoburn.easyshift.dto.template.req.ScheduleTemplateRequest;
 import com.burntoburn.easyshift.entity.templates.ScheduleTemplate;
 import java.util.List;
 

--- a/src/main/java/com/burntoburn/easyshift/service/templates/ScheduleTemplateService.java
+++ b/src/main/java/com/burntoburn/easyshift/service/templates/ScheduleTemplateService.java
@@ -1,6 +1,7 @@
 package com.burntoburn.easyshift.service.templates;
 
 import com.burntoburn.easyshift.dto.template.req.ScheduleTemplateRequest;
+import com.burntoburn.easyshift.dto.template.res.AllScheduleTemplateResponse;
 import com.burntoburn.easyshift.entity.templates.ScheduleTemplate;
 import java.util.List;
 
@@ -13,7 +14,7 @@ public interface ScheduleTemplateService {
     ScheduleTemplate getScheduleTemplateOne(Long id);
 
     // ShiftTemplate 조회 - 전체
-    List<ScheduleTemplate> getAllScheduleTemplates();
+    AllScheduleTemplateResponse getAllScheduleTemplatesByStore(Long storeId);
 
     // 스케줄 템플릿 수정
     ScheduleTemplate updateScheduleTemplate(Long storeId, Long scheduleTemplateId, ScheduleTemplateRequest request);

--- a/src/main/java/com/burntoburn/easyshift/service/templates/imp/ScheduleTemplateServiceImpl.java
+++ b/src/main/java/com/burntoburn/easyshift/service/templates/imp/ScheduleTemplateServiceImpl.java
@@ -47,8 +47,7 @@ public class ScheduleTemplateServiceImpl implements ScheduleTemplateService {
     @Transactional(readOnly = true)
     @Override
     public AllScheduleTemplateResponse getAllScheduleTemplatesByStore(Long storeId) {
-        List<ScheduleTemplate> scheduleTemplateList = scheduleTemplateRepository.findAllByStoreId(storeId)
-                .orElseThrow(() -> new NoSuchElementException("not found StoreId"));
+        List<ScheduleTemplate> scheduleTemplateList = scheduleTemplateRepository.findAllByStoreId(storeId);
 
         return AllScheduleTemplateResponse
                 .fromEntityList(scheduleTemplateList);

--- a/src/main/java/com/burntoburn/easyshift/service/templates/imp/ScheduleTemplateServiceImpl.java
+++ b/src/main/java/com/burntoburn/easyshift/service/templates/imp/ScheduleTemplateServiceImpl.java
@@ -21,20 +21,18 @@ public class ScheduleTemplateServiceImpl implements ScheduleTemplateService {
     private final StoreRepository storeRepository;
     private final ScheduleTemplateFactory scheduleTemplateFactory;
 
+
     @Override
+    @Transactional
     public ScheduleTemplate createScheduleTemplate(Long storeId, ScheduleTemplateRequest request) {
         // Store 조회
         Store store = storeRepository.findById(storeId)
                 .orElseThrow(() -> new NoSuchElementException("Store not found with id: " + storeId));
 
         // ScheduleTemplate 생성
-        ScheduleTemplate scheduleTemplate = scheduleTemplateFactory.createScheduleTemplate(store,request);
+        ScheduleTemplate scheduleTemplate = scheduleTemplateFactory.createScheduleTemplate(store, request);
 
-        // ShiftTemplate 리스트 추가 (scheduleTemplate 참조 X)
-        List<ShiftTemplate> shiftTemplates = scheduleTemplateFactory.createShiftTemplates(request.getShiftTemplates());
 
-        // ShiftTemplates를 이용하여 추가 (일급 컬렉션 적용)
-        scheduleTemplate.getShiftTemplates().update(shiftTemplates);
 
         return scheduleTemplateRepository.save(scheduleTemplate);
     }

--- a/src/main/java/com/burntoburn/easyshift/service/templates/imp/ScheduleTemplateServiceImpl.java
+++ b/src/main/java/com/burntoburn/easyshift/service/templates/imp/ScheduleTemplateServiceImpl.java
@@ -1,6 +1,6 @@
 package com.burntoburn.easyshift.service.templates.imp;
 
-import com.burntoburn.easyshift.dto.schedule.req.scheduleTemplate.ScheduleTemplateRequest;
+import com.burntoburn.easyshift.dto.template.req.ScheduleTemplateRequest;
 import com.burntoburn.easyshift.entity.templates.ScheduleTemplate;
 import com.burntoburn.easyshift.entity.templates.ShiftTemplate;
 import com.burntoburn.easyshift.entity.store.Store;

--- a/src/main/java/com/burntoburn/easyshift/service/templates/imp/ScheduleTemplateServiceImpl.java
+++ b/src/main/java/com/burntoburn/easyshift/service/templates/imp/ScheduleTemplateServiceImpl.java
@@ -1,6 +1,7 @@
 package com.burntoburn.easyshift.service.templates.imp;
 
 import com.burntoburn.easyshift.dto.template.req.ScheduleTemplateRequest;
+import com.burntoburn.easyshift.dto.template.res.AllScheduleTemplateResponse;
 import com.burntoburn.easyshift.entity.templates.ScheduleTemplate;
 import com.burntoburn.easyshift.entity.templates.ShiftTemplate;
 import com.burntoburn.easyshift.entity.store.Store;
@@ -43,9 +44,14 @@ public class ScheduleTemplateServiceImpl implements ScheduleTemplateService {
                 .orElseThrow(() -> new NoSuchElementException("ScheduleTemplate not found with id: " + id));
     }
 
+    @Transactional(readOnly = true)
     @Override
-    public List<ScheduleTemplate> getAllScheduleTemplates() {
-        return scheduleTemplateRepository.findAll();
+    public AllScheduleTemplateResponse getAllScheduleTemplatesByStore(Long storeId) {
+        List<ScheduleTemplate> scheduleTemplateList = scheduleTemplateRepository.findAllByStoreId(storeId)
+                .orElseThrow(() -> new NoSuchElementException("not found StoreId"));
+
+        return AllScheduleTemplateResponse
+                .fromEntityList(scheduleTemplateList);
     }
 
     @Transactional

--- a/src/test/java/com/burntoburn/easyshift/service/leave/imp/LeaveRequestWorkerServiceImpTest.java
+++ b/src/test/java/com/burntoburn/easyshift/service/leave/imp/LeaveRequestWorkerServiceImpTest.java
@@ -1,6 +1,6 @@
 package com.burntoburn.easyshift.service.leave.imp;
 
-import com.burntoburn.easyshift.dto.schedule.req.LeaveRequestDto;
+import com.burntoburn.easyshift.dto.leave.req.LeaveRequestDto;
 import com.burntoburn.easyshift.entity.leave.LeaveRequest;
 import com.burntoburn.easyshift.entity.schedule.Schedule;
 import com.burntoburn.easyshift.entity.user.User;

--- a/src/test/java/com/burntoburn/easyshift/service/templates/imp/ScheduleTemplateServiceImplTest.java
+++ b/src/test/java/com/burntoburn/easyshift/service/templates/imp/ScheduleTemplateServiceImplTest.java
@@ -2,6 +2,7 @@ package com.burntoburn.easyshift.service.templates.imp;
 
 import com.burntoburn.easyshift.dto.template.req.ScheduleTemplateRequest;
 import com.burntoburn.easyshift.dto.template.req.ShiftTemplateRequest;
+import com.burntoburn.easyshift.dto.template.res.AllScheduleTemplateResponse;
 import com.burntoburn.easyshift.entity.templates.ScheduleTemplate;
 import com.burntoburn.easyshift.entity.templates.ShiftTemplate;
 import com.burntoburn.easyshift.entity.store.Store;
@@ -61,7 +62,7 @@ class ScheduleTemplateServiceImplTest {
                 .store(store)
                 .build();
 
-        existingTemplate.getShiftTemplates().addAll(List.of(shift1, shift2)); // ✅ ShiftTemplates 이용하여 추가
+        existingTemplate.getShiftTemplates().addAll(List.of(shift1, shift2)); // ✅ 일급 컬렉션 이용하여 추가
     }
 
     @Test
@@ -110,19 +111,20 @@ class ScheduleTemplateServiceImplTest {
     }
 
     @Test
-    @DisplayName("스케줄 템플릿 전체 조회")
-    void getAllScheduleTemplates() {
+    @DisplayName("특정 매장의 모든 스케줄 템플릿 조회")
+    void getAllScheduleTemplatesByStore() {
         // Given
         List<ScheduleTemplate> templates = List.of(existingTemplate);
-        when(scheduleTemplateRepository.findAll()).thenReturn(templates);
+        when(scheduleTemplateRepository.findAllByStoreId(1L)).thenReturn(Optional.of(templates));
 
         // When
-        List<ScheduleTemplate> result = scheduleTemplateService.getAllScheduleTemplates();
+        AllScheduleTemplateResponse result = scheduleTemplateService.getAllScheduleTemplatesByStore(
+                1L);
 
         // Then
         assertNotNull(result);
-        assertEquals(1, result.size());
-        verify(scheduleTemplateRepository, times(1)).findAll();
+        assertEquals(1, result.getScheduleTemplateResponses().size());
+        verify(scheduleTemplateRepository, times(1)).findAllByStoreId(1L);
     }
 
     @Test

--- a/src/test/java/com/burntoburn/easyshift/service/templates/imp/ScheduleTemplateServiceImplTest.java
+++ b/src/test/java/com/burntoburn/easyshift/service/templates/imp/ScheduleTemplateServiceImplTest.java
@@ -1,7 +1,7 @@
 package com.burntoburn.easyshift.service.templates.imp;
 
-import com.burntoburn.easyshift.dto.schedule.req.scheduleTemplate.ScheduleTemplateRequest;
-import com.burntoburn.easyshift.dto.schedule.req.scheduleTemplate.ShiftTemplateRequest;
+import com.burntoburn.easyshift.dto.template.req.ScheduleTemplateRequest;
+import com.burntoburn.easyshift.dto.template.req.ShiftTemplateRequest;
 import com.burntoburn.easyshift.entity.templates.ScheduleTemplate;
 import com.burntoburn.easyshift.entity.templates.ShiftTemplate;
 import com.burntoburn.easyshift.entity.store.Store;


### PR DESCRIPTION
# [PR] 매장 스케줄 템플릿 CRUD 기능 추가

## 📌 작업 내용
매장의 스케줄 템플릿을 관리할 수 있도록 CRUD API를 추가하였습니다.

### ✅ 기능 추가
1. **스케줄 템플릿 생성 및 수정**
   - **Endpoint:** `POST /api/stores/{store_id}/schedule-templates`
   - **설명:** 특정 매장(`store_id`)에 스케줄 템플릿을 추가하거나 수정합니다.

2. **매장 스케줄 템플릿 목록 조회**
   - **Endpoint:** `GET /api/stores/{store_id}/schedule-templates`
   - **설명:** 특정 매장의 모든 스케줄 템플릿을 조회합니다.

3. **매장 스케줄 템플릿 삭제**
   - **Endpoint:** `DELETE /api/schedule-templates/{schedule_template_id}`
   - **설명:** 특정 스케줄 템플릿(`schedule_template_id`)을 삭제합니다.

## ✅ 리뷰 요청 사항
- RESTful API 설계가 적절한지 검토 부탁드립니다.
- 성능 최적화를 위해 `fetch join` 사용이 필요할지 의견 부탁드립니다.

## 📌 기타 사항
- 기존에 `LazyInitializationException`이 발생했던 부분을 DTO 변환을 통해 해결하였습니다.
- `DELETE` 요청 시 연관된 `ShiftTemplate` 엔티티도 함께 삭제되도록 처리하였습니다.
