### PR TITLE
Feat: 특정 매장 조회, 수정, 유저 목록 반환

### DIFF
--- a/src/main/java/com/burntoburn/easyshift/controller/StoreController.java
+++ b/src/main/java/com/burntoburn/easyshift/controller/StoreController.java
@@ -3,6 +3,7 @@ package com.burntoburn.easyshift.controller;
 import com.burntoburn.easyshift.dto.store.req.StoreCreateRequest;
 import com.burntoburn.easyshift.dto.store.res.StoreDto;
 import com.burntoburn.easyshift.dto.store.res.StoreScheduleResponseDTO;
+import com.burntoburn.easyshift.dto.store.res.StoreUserDTO;
 import com.burntoburn.easyshift.entity.store.Store;
 import com.burntoburn.easyshift.service.StoreService;
 import lombok.RequiredArgsConstructor;
@@ -80,5 +81,11 @@ public class StoreController {
         StoreScheduleResponseDTO response =
                 storeService.getStoreSchedule(storeId, Optional.ofNullable(scheduleId));
         return ResponseEntity.ok(response);
+    }
+
+    @GetMapping("/{storeId}/users")
+    public ResponseEntity<StoreUserDTO> getStoreUsers(@PathVariable Long storeId) {
+        StoreUserDTO storeDetail = storeService.getStoreUser(storeId);
+        return ResponseEntity.ok(storeDetail);
     }
 }

--- a/src/main/java/com/burntoburn/easyshift/dto/store/res/StoreUserDTO.java
+++ b/src/main/java/com/burntoburn/easyshift/dto/store/res/StoreUserDTO.java
@@ -1,0 +1,15 @@
+package com.burntoburn.easyshift.dto.store.res;
+
+import com.burntoburn.easyshift.dto.user.UserDTO;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@Builder
+public class StoreUserDTO {
+    private Long storeId;
+    private String storeName;
+    private List<UserDTO> users;
+}

--- a/src/main/java/com/burntoburn/easyshift/dto/user/UserDTO.java
+++ b/src/main/java/com/burntoburn/easyshift/dto/user/UserDTO.java
@@ -7,6 +7,7 @@ import lombok.Getter;
 @Builder
 public class UserDTO {
     private Long id;
+    private String name;
     private String email;
     private String phoneNumber;
     private String avatarUrl;

--- a/src/main/java/com/burntoburn/easyshift/dto/user/UserDTO.java
+++ b/src/main/java/com/burntoburn/easyshift/dto/user/UserDTO.java
@@ -1,0 +1,14 @@
+package com.burntoburn.easyshift.dto.user;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class UserDTO {
+    private Long id;
+    private String email;
+    private String phoneNumber;
+    private String avatarUrl;
+    private String role;
+}

--- a/src/main/java/com/burntoburn/easyshift/service/StoreService.java
+++ b/src/main/java/com/burntoburn/easyshift/service/StoreService.java
@@ -96,6 +96,7 @@ public class StoreService {
                     var user = userStore.getUser();
                     return UserDTO.builder()
                             .id(user.getId())
+                            .name(user.getName())
                             .email(user.getEmail())
                             .phoneNumber(user.getPhoneNumber())
                             .avatarUrl(user.getAvatarUrl())

--- a/src/main/java/com/burntoburn/easyshift/service/StoreService.java
+++ b/src/main/java/com/burntoburn/easyshift/service/StoreService.java
@@ -10,6 +10,8 @@ import com.burntoburn.easyshift.dto.shift.res.ShiftKey;
 import com.burntoburn.easyshift.dto.store.req.StoreCreateRequest;
 import com.burntoburn.easyshift.dto.store.res.StoreDto;
 import com.burntoburn.easyshift.dto.store.res.StoreScheduleResponseDTO;
+import com.burntoburn.easyshift.dto.store.res.StoreUserDTO;
+import com.burntoburn.easyshift.dto.user.UserDTO;
 import com.burntoburn.easyshift.entity.schedule.Schedule;
 import com.burntoburn.easyshift.entity.schedule.Shift;
 import com.burntoburn.easyshift.entity.store.Store;
@@ -21,6 +23,7 @@ import com.burntoburn.easyshift.repository.store.UserStoreRepository;
 import com.burntoburn.easyshift.repository.user.UserRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDate;
 import java.util.*;
@@ -79,6 +82,35 @@ public class StoreService {
                 })
                 .collect(Collectors.toList());
     }
+
+
+    @Transactional
+    public StoreUserDTO getStoreUser(Long storeId) {
+        Store store = storeRepository.findById(storeId)
+                .orElseThrow(() -> new RuntimeException("해당 매장을 찾을 수 없습니다. id: " + storeId));
+
+        // store.getUserStores()를 통해 연관된 사용자 엔티티를 가져오고, UserDTO로 매핑합니다.
+        // 주의: lazy 로딩 문제를 피하기 위해 fetch join 등을 고려할 수 있습니다.
+        var users = store.getUserStores().stream()
+                .map(userStore -> {
+                    var user = userStore.getUser();
+                    return UserDTO.builder()
+                            .id(user.getId())
+                            .email(user.getEmail())
+                            .phoneNumber(user.getPhoneNumber())
+                            .avatarUrl(user.getAvatarUrl())
+                            .role(user.getRole().toString().toLowerCase()) // 예: "worker", "administrator"
+                            .build();
+                })
+                .collect(Collectors.toList());
+
+        return StoreUserDTO.builder()
+                .storeId(store.getId())
+                .storeName(store.getStoreName())
+                .users(users)
+                .build();
+    }
+
 
     public List<String> linkStoreToUser(String token, Long storeId) {
         Long userId = tokenProvider.getUserIdFromToken(token);

--- a/src/test/java/com/burntoburn/easyshift/store/StoreUserTest.java
+++ b/src/test/java/com/burntoburn/easyshift/store/StoreUserTest.java
@@ -1,0 +1,113 @@
+package com.burntoburn.easyshift.store;
+
+import com.burntoburn.easyshift.entity.store.Store;
+import com.burntoburn.easyshift.entity.store.UserStore;
+import com.burntoburn.easyshift.entity.user.Role;
+import com.burntoburn.easyshift.entity.user.User;
+import com.burntoburn.easyshift.repository.store.StoreRepository;
+import com.burntoburn.easyshift.repository.store.UserStoreRepository;
+import com.burntoburn.easyshift.repository.user.UserRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.util.List;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+public class StoreUserTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private StoreRepository storeRepository;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private UserStoreRepository userStoreRepository;
+
+    private Store testStore;
+
+    @BeforeEach
+    public void setup() {
+        // 데이터베이스 초기화 (테스트에 따라 @Transactional이나 DB 클리어 로직을 추가할 수 있음)
+        userStoreRepository.deleteAll();
+        storeRepository.deleteAll();
+        userRepository.deleteAll();
+
+        // 테스트용 매장 생성
+        testStore = Store.builder()
+                .storeName("매장 A")
+                .build();
+        testStore = storeRepository.save(testStore);
+    }
+
+    @Test
+    public void testGetStoreUsers_whenUsersExist() throws Exception {
+        // 사용자 2명 생성
+        User user1 = User.builder()
+                .email("worker@example.com")
+                .name("Worker User")
+                .phoneNumber("010-1234-5678")
+                .role(Role.WORKER)
+                .avatarUrl("https://example.com/avatar5.png")
+                .build();
+        user1 = userRepository.save(user1);
+
+        User user2 = User.builder()
+                .email("admin@example.com")
+                .name("Admin User")
+                .phoneNumber("010-9876-5432")
+                .role(Role.ADMINISTRATOR)
+                .avatarUrl("https://example.com/avatar6.png")
+                .build();
+        user2 = userRepository.save(user2);
+
+        // 매장과 사용자 연결(UserStore 생성)
+        UserStore us1 = UserStore.builder()
+                .store(testStore)
+                .user(user1)
+                .build();
+        UserStore us2 = UserStore.builder()
+                .store(testStore)
+                .user(user2)
+                .build();
+        userStoreRepository.saveAll(List.of(us1, us2));
+
+        // GET /api/stores/{storeId}/users 호출
+        mockMvc.perform(get("/api/stores/{storeId}/users", testStore.getId())
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                // 응답 JSON 구조 검증
+                .andExpect(jsonPath("$.storeId").value(testStore.getId()))
+                .andExpect(jsonPath("$.storeName").value(testStore.getStoreName()))
+                // 두 명의 사용자가 반환되어야 함
+                .andExpect(jsonPath("$.users.length()").value(2))
+                // 첫 번째 사용자 검증 (순서는 보장되지 않으므로 email 등으로 검사)
+                .andExpect(jsonPath("$.users[?(@.email=='worker@example.com')].phoneNumber").exists())
+                .andExpect(jsonPath("$.users[?(@.email=='admin@example.com')].avatarUrl").exists());
+    }
+
+    @Test
+    public void testGetStoreUsers_whenNoUsers() throws Exception {
+        // 매장에 연결된 사용자가 없는 경우
+        mockMvc.perform(get("/api/stores/{storeId}/users", testStore.getId())
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                // users 배열는 빈 리스트여야 함
+                .andExpect(jsonPath("$.storeId").value(testStore.getId()))
+                .andExpect(jsonPath("$.storeName").value(testStore.getStoreName()))
+                .andExpect(jsonPath("$.users").isEmpty());
+    }
+}


### PR DESCRIPTION
## 변경 사항
### 특정 매장 조회 변경
- 매장 조회의 경우 기본 GET /{storeId}에서 /details/{storeId}로 변경됩니다.
- 기본 GET의 경우 매장 이름 수정 시 기본적인 확인을 위한 요청이 됩니다.

### 특정 매장 수정 구현
- 매장 이름 변경을 구현하였습니다.

### 특정 매장의 유저 목록 반환 구현
- 매장에 해당하는 유저를 반환하는 경우 다음과 같은 response를 수행합니다.
```
    "storeId": 1,
        "storeName": "매장 A",
        "users": [
            {
                "id": 5,
                "name": "조장호",
                "email": "worker@example.com",
                "phoneNumber": "010-1234-5678",
                "avatarUrl": "https://example.com/avatar5.png",
                "role": "worker"
            },
            {
                "id": 6,
                "name": "김찬호",
                "email": "admin@example.com",
                "phoneNumber": "010-9876-5432",
                "avatarUrl": "https://example.com/avatar6.png",
                "role": "administrator"
            }
        ]
```
- success, error 같은 경우 추후에 필요하다면 dto로 감싸서 반환할 예정입니다.
- 해당 기능의 service 부분에서 store -> userStore 조회하는 과정에서 세션이 종료되면 조회가 되지 않는 문제가 발생해서 @transaction으로 묶어서 코드를 작성했는데 괜찮을까요? @IamGroooooot 