### PR TITLE
스케줄 서비스 예외 처리 개선 및 단위 테스트 추가

### DIFF
--- a/src/main/java/com/burntoburn/easyshift/exception/schedule/ScheduleErrorCode.java
+++ b/src/main/java/com/burntoburn/easyshift/exception/schedule/ScheduleErrorCode.java
@@ -9,7 +9,10 @@ import org.springframework.http.HttpStatus;
 @RequiredArgsConstructor
 public enum ScheduleErrorCode implements ErrorCode {
     SCHEDULE_NOT_FOUND(HttpStatus.NOT_FOUND, 1001, "해당 스케줄을 찾을 수 없습니다."),
-    INSUFFICIENT_USERS_FOR_ASSIGNMENT(HttpStatus.BAD_REQUEST, 1002, "자동 배정을 수행하기에 근무 가능한 사용자가 부족합니다.");
+    INSUFFICIENT_USERS_FOR_ASSIGNMENT(HttpStatus.BAD_REQUEST, 1002, "자동 배정을 수행하기에 근무 가능한 사용자가 부족합니다."),
+
+    SCHEDULE_PAGE_NOT_FOUND(HttpStatus.NOT_FOUND, 2002, "요청한 페이지에 스케줄이 존재하지 않습니다.");
+
 
     private final HttpStatus httpStatus;
     private final int code;

--- a/src/main/java/com/burntoburn/easyshift/exception/schedule/ScheduleException.java
+++ b/src/main/java/com/burntoburn/easyshift/exception/schedule/ScheduleException.java
@@ -19,4 +19,7 @@ public class ScheduleException extends BusinessException {
     public static ScheduleException insufficientUsersForAssignment() {
         return new ScheduleException(INSUFFICIENT_USERS_FOR_ASSIGNMENT);
     }
+    public static ScheduleException schedulePageNotFound() {
+        return new ScheduleException(ScheduleErrorCode.SCHEDULE_PAGE_NOT_FOUND);
+    }
 }

--- a/src/main/java/com/burntoburn/easyshift/exception/shift/ShiftErrorCode.java
+++ b/src/main/java/com/burntoburn/easyshift/exception/shift/ShiftErrorCode.java
@@ -8,7 +8,9 @@ import org.springframework.http.HttpStatus;
 @Getter
 @RequiredArgsConstructor
 public enum ShiftErrorCode implements ErrorCode {
-    SHIFT_NOT_FOUND(HttpStatus.NOT_FOUND, 1001, "해당 시프트을 찾을 수 없습니다.");
+    SHIFT_NOT_FOUND(HttpStatus.NOT_FOUND, 1001, "해당 시프트을 찾을 수 없습니다."),
+    SHIFT_NOT_FOUND_IN_PERIOD(HttpStatus.NOT_FOUND, 1002, "해당 기간에 대한 시프트를 찾을 수 없습니다."),
+    ;
 
     private final HttpStatus httpStatus;
     private final int code;

--- a/src/main/java/com/burntoburn/easyshift/exception/shift/ShiftException.java
+++ b/src/main/java/com/burntoburn/easyshift/exception/shift/ShiftException.java
@@ -2,6 +2,7 @@ package com.burntoburn.easyshift.exception.shift;
 
 
 import static com.burntoburn.easyshift.exception.shift.ShiftErrorCode.SHIFT_NOT_FOUND;
+import static com.burntoburn.easyshift.exception.shift.ShiftErrorCode.SHIFT_NOT_FOUND_IN_PERIOD;
 
 import com.burntoburn.easyshift.common.exception.BusinessException;
 import com.burntoburn.easyshift.common.exception.ErrorCode;
@@ -15,5 +16,7 @@ public class ShiftException extends BusinessException {
     public static ShiftException shiftNotFound() {
         return new ShiftException(SHIFT_NOT_FOUND);
     }
-
+    public static ShiftException shiftNotFoundInPeriod() {
+        return new ShiftException(SHIFT_NOT_FOUND_IN_PERIOD);
+    }
 }

--- a/src/main/java/com/burntoburn/easyshift/repository/schedule/ScheduleRepository.java
+++ b/src/main/java/com/burntoburn/easyshift/repository/schedule/ScheduleRepository.java
@@ -51,4 +51,6 @@ public interface ScheduleRepository extends JpaRepository<Schedule, Long> {
     WHERE s.scheduleTemplateId = :scheduleTemplateId
     """)
     List<Schedule>findSchedulesWithTemplate(Long scheduleTemplateId);
+
+    boolean existsByStoreId(Long storeId);
 }

--- a/src/test/java/com/burntoburn/easyshift/service/schedule/imp/ScheduleServiceImpTest.java
+++ b/src/test/java/com/burntoburn/easyshift/service/schedule/imp/ScheduleServiceImpTest.java
@@ -1,27 +1,360 @@
 package com.burntoburn.easyshift.service.schedule.imp;
 
+import static org.hibernate.validator.internal.util.Contracts.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
-
+import com.burntoburn.easyshift.dto.schedule.req.ScheduleUpload;
+import com.burntoburn.easyshift.dto.schedule.req.ShiftDetail;
+import com.burntoburn.easyshift.dto.schedule.res.ScheduleDetailDTO;
+import com.burntoburn.easyshift.dto.schedule.res.ScheduleInfoResponse;
+import com.burntoburn.easyshift.dto.schedule.res.WorkerScheduleResponse;
 import com.burntoburn.easyshift.entity.schedule.Schedule;
+import com.burntoburn.easyshift.entity.schedule.ScheduleStatus;
 import com.burntoburn.easyshift.entity.schedule.Shift;
 import com.burntoburn.easyshift.entity.store.Store;
 import com.burntoburn.easyshift.entity.templates.ScheduleTemplate;
 
+import com.burntoburn.easyshift.entity.templates.ShiftTemplate;
 import com.burntoburn.easyshift.repository.schedule.ScheduleRepository;
 import com.burntoburn.easyshift.repository.schedule.ScheduleTemplateRepository;
 import com.burntoburn.easyshift.repository.schedule.ShiftRepository;
 import com.burntoburn.easyshift.repository.store.StoreRepository;
+import com.burntoburn.easyshift.repository.store.UserStoreRepository;
+import com.burntoburn.easyshift.repository.user.UserRepository;
 import com.burntoburn.easyshift.service.schedule.ScheduleFactory;
 
+
+import java.time.DayOfWeek;
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.time.YearMonth;
+import java.time.format.DateTimeFormatter;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.test.util.ReflectionTestUtils;
+import static org.assertj.core.api.Assertions.*;
 
 @ExtendWith(MockitoExtension.class)
 class ScheduleServiceImpTest {
+
+    @InjectMocks
+    ScheduleServiceImp scheduleService;
+
+    @Mock
+    private UserStoreRepository userStoreRepository;
+    @Mock
+    private UserRepository userRepository;
+    @Mock
+    private StoreRepository storeRepository;
+    @Mock
+    private ScheduleTemplateRepository scheduleTemplateRepository;
+    @Mock
+    private ShiftRepository shiftRepository;
+    @Mock
+    private ScheduleRepository scheduleRepository;
+    @Mock
+    private ScheduleFactory scheduleFactory;
+
+
+    @Test
+    @DisplayName("스케줄 생성 성공")
+    void createSchedule_success(){
+        // given: 요청 객체 설정
+        ScheduleUpload request = new ScheduleUpload();
+        ReflectionTestUtils.setField(request, "scheduleName", "Test Schedule");
+        ReflectionTestUtils.setField(request, "storeId", 1L);
+        ReflectionTestUtils.setField(request, "scheduleMonth", YearMonth.of(2025, 3));
+        ReflectionTestUtils.setField(request, "scheduleTemplateId", 2L);
+        ReflectionTestUtils.setField(request, "description", "Test Description");
+
+        // ShiftDetail 리스트 생성 (ShiftTemplateId와 expectedWorkers 정의)
+        List<ShiftDetail> shiftDetails = List.of(
+                new ShiftDetail(10L, 2), // ShiftTemplate 10번에 대해 2개의 Shift 생성 기대
+                new ShiftDetail(20L, 3)  // ShiftTemplate 20번에 대해 3개의 Shift 생성 기대
+        );
+        ReflectionTestUtils.setField(request, "shiftDetails", shiftDetails);
+
+        // Store 및 ScheduleTemplate Mock 설정
+        Store store = Store.builder()
+                .id(1L)
+                .storeName("Test Store")
+                .build();
+
+        ScheduleTemplate scheduleTemplate = ScheduleTemplate.builder()
+                .id(2L)
+                .scheduleTemplateName("Test Template")
+                .build();
+
+        // ShiftTemplate Mock (Shift 생성 시 참조됨)
+        ShiftTemplate shiftTemplate1 = ShiftTemplate.builder()
+                .id(10L)
+                .shiftTemplateName("Morning Shift")
+                .startTime(LocalTime.parse("08:00"))
+                .endTime(LocalTime.parse("12:00"))
+                .build();
+
+        ShiftTemplate shiftTemplate2 = ShiftTemplate.builder()
+                .id(20L)
+                .shiftTemplateName("Evening Shift")
+                .startTime(LocalTime.parse("17:00"))
+                .endTime(LocalTime.parse("21:00"))
+                .build();
+
+        // 빌더 패턴을 사용하여 Shift 리스트 생성
+        List<Shift> generatedShifts = new ArrayList<>();
+        for (int day = 1; day <= 31; day++) { // 31일짜리 달 (예: 3월) 기준으로 생성
+            generatedShifts.add(Shift.builder()
+                    .schedule(null)
+                    .shiftDate(request.getScheduleMonth().atDay(day))
+                    .shiftName(shiftTemplate1.getShiftTemplateName())
+                    .shiftTemplateId(shiftTemplate1.getId())
+                    .startTime(shiftTemplate1.getStartTime())
+                    .endTime(shiftTemplate1.getEndTime())
+                    .user(null)
+                    .build());
+
+            generatedShifts.add(Shift.builder()
+                    .schedule(null)
+                    .shiftDate(request.getScheduleMonth().atDay(day))
+                    .shiftName(shiftTemplate1.getShiftTemplateName())
+                    .shiftTemplateId(shiftTemplate1.getId())
+                    .startTime(shiftTemplate1.getStartTime())
+                    .endTime(shiftTemplate1.getEndTime())
+                    .user(null)
+                    .build());
+
+            generatedShifts.add(Shift.builder()
+                    .schedule(null)
+                    .shiftDate(request.getScheduleMonth().atDay(day))
+                    .shiftName(shiftTemplate2.getShiftTemplateName())
+                    .shiftTemplateId(shiftTemplate2.getId())
+                    .startTime(shiftTemplate2.getStartTime())
+                    .endTime(shiftTemplate2.getEndTime())
+                    .user(null)
+                    .build());
+
+            generatedShifts.add(Shift.builder()
+                    .schedule(null)
+                    .shiftDate(request.getScheduleMonth().atDay(day))
+                    .shiftName(shiftTemplate2.getShiftTemplateName())
+                    .shiftTemplateId(shiftTemplate2.getId())
+                    .startTime(shiftTemplate2.getStartTime())
+                    .endTime(shiftTemplate2.getEndTime())
+                    .user(null)
+                    .build());
+
+            generatedShifts.add(Shift.builder()
+                    .schedule(null)
+                    .shiftDate(request.getScheduleMonth().atDay(day))
+                    .shiftName(shiftTemplate2.getShiftTemplateName())
+                    .shiftTemplateId(shiftTemplate2.getId())
+                    .startTime(shiftTemplate2.getStartTime())
+                    .endTime(shiftTemplate2.getEndTime())
+                    .user(null)
+                    .build());
+        }
+
+        // Schedule 객체 Mock 설정
+        Schedule schedule = Schedule.builder()
+                .id(100L)
+                .scheduleName(request.getScheduleName())
+                .store(store)
+                .scheduleMonth(request.getScheduleMonth())
+                .description(request.getDescription())
+                .shifts(generatedShifts)
+                .build();
+
+        // Mock 설정
+        when(storeRepository.findById(1L)).thenReturn(Optional.of(store));
+        when(scheduleTemplateRepository.findById(2L)).thenReturn(Optional.of(scheduleTemplate));
+        when(scheduleFactory.createSchedule(store, scheduleTemplate, request)).thenReturn(schedule);
+        when(scheduleRepository.save(any(Schedule.class))).thenReturn(schedule);
+
+        // when: 스케줄 생성 실행
+        scheduleService.createSchedule(request);
+
+        // then: 검증
+        verify(storeRepository, times(1)).findById(1L);
+        verify(scheduleTemplateRepository, times(1)).findById(2L);
+        verify(scheduleFactory, times(1)).createSchedule(store, scheduleTemplate, request);
+        verify(scheduleRepository, times(1)).save(schedule);
+
+        // Shift가 예상대로 생성되었는지 검증
+        assertNotNull(schedule.getShifts());
+        assertEquals(31 * (2 + 3), schedule.getShifts().size()); // 31일 x (2+3)개의 Shift 생성 확인
+
+        // 특정 날짜에 Shift가 올바르게 생성되었는지 확인
+        Shift sampleShift = schedule.getShifts().get(0);
+        assertNotNull(sampleShift.getShiftDate());
+        assertNotNull(sampleShift.getShiftTemplateId());
+        assertNotNull(sampleShift.getShiftName());
+    }
+
+    @Test
+    @DisplayName("매장 스케줄 목록 조회 성공")
+    void getSchedulesByStore_success(){
+        // given
+        Long storeId = 1L;
+        Pageable pageable = PageRequest.of(0,10);
+
+        Store store = Store.builder()
+                .id(storeId)
+                .storeCode(UUID.randomUUID())
+                .storeName("test")
+                .description("asda")
+                .build();
+
+        // Schedule 객체 Mock 설정
+        Schedule schedule = Schedule.builder()
+                .id(100L)
+                .scheduleStatus(ScheduleStatus.PENDING)
+                .scheduleName("test")
+                .store(store)
+                .scheduleMonth(YearMonth.now())
+                .description("test")
+                .build();
+
+        List<Schedule> schedules = List.of(schedule);
+        Page<Schedule> schedulePage = new PageImpl<>(schedules, pageable, schedules.size()); // Page 객체 생성
+
+        // Mock 설정
+        when(scheduleRepository.findByStoreIdOrderByCreatedAtDesc(1L,pageable)).thenReturn(schedulePage);
+
+        // when
+        ScheduleInfoResponse response = scheduleService.getSchedulesByStore(storeId, pageable);
+
+        //then
+        verify(scheduleRepository, times(1)).findByStoreIdOrderByCreatedAtDesc(storeId, pageable);
+
+        assertThat(response).isNotNull();
+        assertThat(response.getSchedules()).hasSize(1);
+        assertThat(response.getPageInfoDTO().isLast()).isTrue();
+    }
+
+
+
+    @Test
+    @DisplayName("스케줄 삭제 성공")
+    void deleteSchedule_success(){
+        // given
+        Long scheduleId = 100L;
+        Schedule schedule = Schedule.builder()
+                .id(scheduleId)
+                .scheduleName("Test Schedule")
+                .build();
+
+        when(scheduleRepository.findById(scheduleId)).thenReturn(Optional.of(schedule));
+
+        // when
+        scheduleService.deleteSchedule(scheduleId);
+
+        // then
+        verify(scheduleRepository, times(1)).findById(scheduleId);
+        verify(scheduleRepository, times(1)).delete(schedule);
+    }
+
+
+    @Test
+    @DisplayName("worker 의 스케줄 조회 성공")
+    void getSchedulesByWorker_success(){
+        // given
+        Long storeId = 1L;
+        Long userId = 10L;
+        String date = "2025-03";
+        YearMonth scheduleMonth = YearMonth.parse(date, DateTimeFormatter.ofPattern("yyyy-MM"));
+
+        Store store = Store.builder().id(storeId).storeName("Test Store").build();
+        Schedule schedule = Schedule.builder().id(100L).store(store).scheduleMonth(scheduleMonth).build();
+        List<Schedule> schedules = List.of(schedule);
+
+        when(scheduleRepository.findWorkerSchedules(storeId, scheduleMonth, userId)).thenReturn(schedules);
+
+        // when
+        WorkerScheduleResponse response = scheduleService.getSchedulesByWorker(storeId, userId, date);
+
+        // then
+        verify(scheduleRepository, times(1)).findWorkerSchedules(storeId, scheduleMonth, userId);
+        assertThat(response).isNotNull();
+        assertThat(response.getSchedules()).hasSize(1);
+    }
+
+
+    @Test
+    @DisplayName("스케줄 조회(all) 성공")
+    void getAllSchedules_success() {
+        // given
+        Long scheduleId = 100L;
+        Store store = Store.builder()
+                .id(1L)
+                .storeName("Test Store")
+                .build();
+
+        Schedule schedule = Schedule.builder()
+                .id(scheduleId)
+                .scheduleName("Test Schedule")
+                .store(store)
+                .scheduleMonth(YearMonth.of(2025, 3))
+                .description("Test Description")
+                .build();
+
+        ScheduleTemplate scheduleTemplate = ScheduleTemplate.builder()
+                .id(200L)
+                .scheduleTemplateName("Test Template")
+                .build();
+
+        List<ShiftTemplate> shiftTemplates = List.of(
+                ShiftTemplate.builder()
+                        .id(10L)
+                        .shiftTemplateName("Morning Shift")
+                        .startTime(LocalTime.parse("08:00"))
+                        .endTime(LocalTime.parse("12:00"))
+                        .build()
+        );
+
+        List<Shift> shifts = List.of(
+                Shift.builder()
+                        .id(300L)
+                        .schedule(schedule)
+                        .shiftDate(schedule.getScheduleMonth().atDay(1))
+                        .shiftName("Morning Shift")
+                        .shiftTemplateId(10L)
+                        .startTime(LocalTime.parse("08:00"))
+                        .endTime(LocalTime.parse("12:00"))
+                        .user(null)
+                        .build()
+        );
+
+        when(scheduleRepository.findScheduleWithShifts(scheduleId)).thenReturn(Optional.of(schedule));
+        when(scheduleTemplateRepository.findScheduleTemplateWithShiftsById(schedule.getScheduleTemplateId())).thenReturn(Optional.of(scheduleTemplate));
+
+        ReflectionTestUtils.setField(scheduleTemplate, "shiftTemplates", shiftTemplates);
+        ReflectionTestUtils.setField(schedule, "shifts", shifts);
+
+        // when
+        ScheduleDetailDTO response = scheduleService.getAllSchedules(scheduleId);
+
+        // then
+        verify(scheduleRepository, times(1)).findScheduleWithShifts(scheduleId);
+        verify(scheduleTemplateRepository, times(1)).findScheduleTemplateWithShiftsById(schedule.getScheduleTemplateId());
+
+        assertThat(response).isNotNull();
+        assertThat(response.getShifts()).hasSize(1);
+    }
 
 }


### PR DESCRIPTION
## 작업 내용

### 예외 처리 추가 및 개선
- 특정 상황에서 발생하는 예외를 보다 명확하게 구분하여 ScheduleException, ShiftException 등을 추가
- 기존 예외 메시지를 보강하고, 보다 직관적인 ErrorCode를 사용하도록 개선
### Mock 기반 단위 테스트 추가
- ScheduleService의 주요 기능에 대한 단위 테스트 추가 (createSchedule_success, getAllSchedules_success 등)
- Mockito를 활용하여 데이터베이스 의존성을 제거하고, 테스트의 독립성을 보장
- ReflectionTestUtils를 활용하여 private 필드 값을 주입하는 방식으로 테스트 안정성 확보

### 기존 예외 처리 로직 리팩토링
- 스케줄이 없는 예외인지 요청한 페이지에 데이터 없는 예외인지 분리

## Test
<img width="1023" alt="image" src="https://github.com/user-attachments/assets/20ac0318-1ceb-48aa-ac13-63dc684ae410" />
