### PR TITLE
로그인 관련 수정 사항입니다.

### DIFF
--- a/src/main/java/com/burntoburn/easyshift/config/SecurityConfig.java
+++ b/src/main/java/com/burntoburn/easyshift/config/SecurityConfig.java
@@ -42,7 +42,7 @@ public class SecurityConfig {
             "/", "/css/**", "/images/**", "/js/**", "/favicon.ico", "/h2-console/**"
     };
     private static final String[] PUBLIC_API_ENDPOINTS = {
-            "/api/user/info", "/api/user/login", "/api/public/**", "/api/auth/**", "/oauth2/**", "/login/**"
+            "/api/user/login", "/api/public/**", "/api/auth/**", "/oauth2/**", "/login/**"
     };
 
     @Bean

--- a/src/main/java/com/burntoburn/easyshift/controller/TokenApiController.java
+++ b/src/main/java/com/burntoburn/easyshift/controller/TokenApiController.java
@@ -10,7 +10,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
-@RequestMapping(("/login"))
+@RequestMapping()
 @RequiredArgsConstructor
 @Slf4j
 public class TokenApiController {
@@ -19,7 +19,7 @@ public class TokenApiController {
 
     @PostMapping("/token")
     public ResponseEntity<CreateAccessTokenResponse> createAccessToken(@RequestBody CreateAccessTokenRequest request){
-        String newToken = tokenService.createNewAccessToken(request.getRefreshToken());
+        String newToken = tokenService.createNewAccessTokenByRefreshToken(request.getRefreshToken());
         return ResponseEntity.status(HttpStatus.CREATED).body(new CreateAccessTokenResponse(newToken));
     }
 

--- a/src/main/java/com/burntoburn/easyshift/controller/UserApiController.java
+++ b/src/main/java/com/burntoburn/easyshift/controller/UserApiController.java
@@ -39,11 +39,11 @@ public class UserApiController {
 
 
     @GetMapping("/profile")
-    public ResponseEntity<ApiResponse<User>> getUserProfile() {
+    public ResponseEntity<ApiResponse<UserInfoResponse>> getUserProfile() {
         CustomUserDetails userDetails = SecurityUtil.getCurrentUser();
-        User user = userService.findById(userDetails.getUserId());
+        UserInfoResponse response = new UserInfoResponse(userService.findById(userDetails.getUserId()));
 
-        return ResponseEntity.ok(ApiResponse.success(user));
+        return ResponseEntity.ok(ApiResponse.success(response));
     }
 
 //    @GetMapping("/logout")

--- a/src/main/java/com/burntoburn/easyshift/dto/user/UserInfoResponse.java
+++ b/src/main/java/com/burntoburn/easyshift/dto/user/UserInfoResponse.java
@@ -1,0 +1,26 @@
+package com.burntoburn.easyshift.dto.user;
+
+import com.burntoburn.easyshift.entity.user.Role;
+import com.burntoburn.easyshift.entity.user.User;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+@AllArgsConstructor
+public class UserInfoResponse {
+    private String name;
+    private String email;
+    private String phoneNumber;
+    private String avatarUrl;
+    private Role role;
+
+    public UserInfoResponse(User user) {
+        this.name = user.getName();
+        this.email = user.getEmail();
+        this.phoneNumber = user.getPhoneNumber();
+        this.avatarUrl = user.getAvatarUrl();
+        this.role = user.getRole();
+    }
+}

--- a/src/main/java/com/burntoburn/easyshift/service/user/TokenService.java
+++ b/src/main/java/com/burntoburn/easyshift/service/user/TokenService.java
@@ -13,9 +13,8 @@ public class TokenService {
 
     private final TokenProvider tokenProvider;
     private final RefreshTokenService refreshTokenService;
-    private final UserService userService;
 
-    public String createNewAccessToken(String refreshToken) {
+    public String createNewAccessTokenByRefreshToken(String refreshToken) {
         if (!tokenProvider.validToken(refreshToken)) {
             throw new IllegalArgumentException("유효하지 않은 토큰 입니다.");
         }
@@ -25,4 +24,11 @@ public class TokenService {
 
         return tokenProvider.generateAccessToken(user, Duration.ofHours(2));
     }
+
+    public String createNewAccessToken(User user) {
+
+        return tokenProvider.generateAccessToken(user, Duration.ofHours(2));
+    }
+
+
 }


### PR DESCRIPTION
1. api/user/info 에 대한 접근이 모두허용으로 되어있는 점public endpoint 에서 제거했습니다.

2. api/user/info 에서 유저 정보가 갱신 될 때 새로운 엑세스 토큰을 발급해서 헤더에 엑세스 토큰이 추가되어 응답이 갑니다.

3. user 정보 조회시 response DTO 객체를 생성해 반환하게 됩니다.