### PR TITLE
유저 정보 조회 API 추가 및 시간 포맷 변경, 예외 처리 개선

### DIFF
--- a/src/main/java/com/burntoburn/easyshift/controller/UserApiController.java
+++ b/src/main/java/com/burntoburn/easyshift/controller/UserApiController.java
@@ -11,11 +11,15 @@ import com.burntoburn.easyshift.util.SecurityUtil;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequiredArgsConstructor
+@RequestMapping("/api/user")
 public class UserApiController {
 
     private final UserService userService;
@@ -34,11 +38,9 @@ public class UserApiController {
     }
 
 
-    //    @GetMapping("/profile")
-    public ResponseEntity<ApiResponse<UserInfoResponse>> getUserProfile() {
-        CustomUserDetails userDetails = SecurityUtil.getCurrentUser();
-        UserInfoResponse response = new UserInfoResponse(userService.findById(userDetails.getUserId()));
-
+    @GetMapping("/profile")
+    public ResponseEntity<ApiResponse<UserInfoResponse>> getUserProfile(@AuthenticationPrincipal Long userId) {
+        UserInfoResponse response = new UserInfoResponse(userService.findById(userId));
         return ResponseEntity.ok(ApiResponse.success(response));
     }
 

--- a/src/main/java/com/burntoburn/easyshift/dto/template/ShiftTemplateDto.java
+++ b/src/main/java/com/burntoburn/easyshift/dto/template/ShiftTemplateDto.java
@@ -1,6 +1,7 @@
 package com.burntoburn.easyshift.dto.template;
 
 import com.burntoburn.easyshift.entity.templates.ShiftTemplate;
+import com.fasterxml.jackson.annotation.JsonFormat;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -11,7 +12,11 @@ import lombok.NoArgsConstructor;
 public class ShiftTemplateDto {
     private Long shiftTemplateId;
     private String shiftTemplateName;
+
+    @JsonFormat(pattern = "HH:mm")
     private String startTime;
+
+    @JsonFormat(pattern = "HH:mm")
     private String endTime;
 
     public static ShiftTemplateDto fromEntity(ShiftTemplate shiftTemplate) {

--- a/src/main/java/com/burntoburn/easyshift/dto/template/req/ShiftTemplateRequest.java
+++ b/src/main/java/com/burntoburn/easyshift/dto/template/req/ShiftTemplateRequest.java
@@ -1,6 +1,5 @@
 package com.burntoburn.easyshift.dto.template.req;
 
-import java.time.LocalTime;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -12,6 +11,6 @@ import lombok.NoArgsConstructor;
 @Builder
 public class ShiftTemplateRequest {
     private String shiftName;
-    private LocalTime startTime;
-    private LocalTime endTime;
+    private String startTime;
+    private String endTime;
 }

--- a/src/main/java/com/burntoburn/easyshift/dto/user/UserInfoResponse.java
+++ b/src/main/java/com/burntoburn/easyshift/dto/user/UserInfoResponse.java
@@ -20,7 +20,7 @@ public class UserInfoResponse {
         this.name = user.getName();
         this.email = user.getEmail();
         this.phoneNumber = user.getPhoneNumber();
-        this.avatarUrl = user.getAvatarUrl();
         this.role = user.getRole();
+        this.avatarUrl = user.getAvatarUrl();
     }
 }

--- a/src/main/java/com/burntoburn/easyshift/service/templates/ScheduleTemplateFactory.java
+++ b/src/main/java/com/burntoburn/easyshift/service/templates/ScheduleTemplateFactory.java
@@ -5,6 +5,8 @@ import com.burntoburn.easyshift.dto.template.req.ShiftTemplateRequest;
 import com.burntoburn.easyshift.entity.store.Store;
 import com.burntoburn.easyshift.entity.templates.ScheduleTemplate;
 import com.burntoburn.easyshift.entity.templates.ShiftTemplate;
+import java.time.LocalTime;
+import java.time.format.DateTimeFormatter;
 import org.springframework.stereotype.Component;
 
 import java.util.Collections;
@@ -14,6 +16,7 @@ import java.util.stream.Collectors;
 
 @Component
 public class ScheduleTemplateFactory {
+    private static final DateTimeFormatter TIME_FORMATTER = DateTimeFormatter.ofPattern("HH:mm");
 
     public ScheduleTemplate createScheduleTemplate(Store store, ScheduleTemplateRequest request) {
         // ShiftTemplates 객체를 미리 초기화하여 null 방지
@@ -38,8 +41,8 @@ public class ScheduleTemplateFactory {
                 .map(shiftRequest -> ShiftTemplate.builder()
                         .scheduleTemplate(scheduleTemplate)
                         .shiftTemplateName(shiftRequest.getShiftName())
-                        .startTime(shiftRequest.getStartTime())
-                        .endTime(shiftRequest.getEndTime())
+                        .startTime(LocalTime.parse(shiftRequest.getStartTime(), TIME_FORMATTER))
+                        .endTime(LocalTime.parse(shiftRequest.getEndTime(),TIME_FORMATTER))
                         .build())
                 .collect(Collectors.toList());
     }

--- a/src/main/java/com/burntoburn/easyshift/service/templates/imp/ScheduleTemplateServiceImpl.java
+++ b/src/main/java/com/burntoburn/easyshift/service/templates/imp/ScheduleTemplateServiceImpl.java
@@ -5,6 +5,7 @@ import com.burntoburn.easyshift.dto.template.req.ScheduleTemplateRequest;
 import com.burntoburn.easyshift.dto.template.ScheduleTemplateWithShiftsResponse;
 import com.burntoburn.easyshift.entity.store.Store;
 import com.burntoburn.easyshift.entity.templates.ScheduleTemplate;
+import com.burntoburn.easyshift.exception.store.StoreException;
 import com.burntoburn.easyshift.exception.template.TemplateException;
 import com.burntoburn.easyshift.repository.schedule.ScheduleTemplateRepository;
 import com.burntoburn.easyshift.repository.store.StoreRepository;
@@ -28,8 +29,7 @@ public class ScheduleTemplateServiceImpl implements ScheduleTemplateService {
     @Transactional
     public ScheduleTemplateResponse createScheduleTemplate(Long storeId, ScheduleTemplateRequest request) {
         // Store 조회
-        Store store = storeRepository.findById(storeId)
-                .orElseThrow(()->new NoSuchElementException("not found store"));
+        Store store = storeRepository.findById(storeId).orElseThrow(StoreException::storeNotFound);
 
         // ScheduleTemplate 생성
         ScheduleTemplate scheduleTemplate = scheduleTemplateFactory.createScheduleTemplate(store, request);


### PR DESCRIPTION
## 📌 작업 내용
이번 PR에서는 다음과 같은 기능이 추가되었습니다.

### 유저 정보 조회 API 추가
- 유저 정보를 조회할 수 있는 API 엔드포인트를 추가했습니다.
- 해당 API를 통해 특정 유저의 정보를 가져올 수 있습니다.

### 시간 포맷을 HH:mm 형식으로 변경
- 기존 HH:mm:ss 형식이 아닌 HH:mm 포맷을 사용하도록 수정했습니다.
- SHIFT 테이블의 START_TIME, END_TIME 컬럼에 적용되었습니다.

### storeId가 유효하지 않을 경우 예외 처리 추가
- storeId가 존재하지 않는 경우 예외가 발생하도록 처리했습니다.
- 적절한 에러 메시지를 반환하여 클라이언트에서 쉽게 오류를 인지할 수 있도록 개선했습니다.